### PR TITLE
Generate a licenses.json file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
 			<version>1.2.13</version>
 		</dependency>
 		<dependency>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>

--- a/src/org/spdx/html/LicenseTOCJSONFile.java
+++ b/src/org/spdx/html/LicenseTOCJSONFile.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2011 Source Auditor Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.spdx.html;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.spdx.rdfparser.license.SpdxListedLicense;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+/**
+ * This class holds a JSON file for a license table of contents
+ * @author Kyle E. Mitchell
+ *
+ */
+public class LicenseTOCJSONFile {
+	
+	public class ListedSpdxLicense {
+		private String reference;
+		private String refNumber;
+		private String licenseId;
+		private boolean osiApproved;
+		private String licenseName;
+		
+		public ListedSpdxLicense() {
+			reference = null;
+			refNumber = null;
+			licenseId = null;
+			osiApproved = false;
+			licenseName = null;
+		}
+		
+		public ListedSpdxLicense(String reference, String refNumber, 
+				String licenseId, boolean isOsiApproved, String licenseName) {
+			this.reference = reference;
+			this.refNumber = refNumber;
+			this.licenseId = licenseId;
+			this.osiApproved = osiApproved;
+			this.licenseName = licenseName;
+		}
+
+		public String getReference() {
+			return reference;
+		}
+
+		public void setReference(String reference) {
+			this.reference = reference;
+		}
+
+		public String getRefNumber() {
+			return refNumber;
+		}
+
+		public void setRefNumber(String refNumber) {
+			this.refNumber = refNumber;
+		}
+
+		public String getLicenseId() {
+			return licenseId;
+		}
+
+		public void setLicenseId(String licenseId) {
+			this.licenseId = licenseId;
+		}
+
+		public boolean getOsiApproved() {
+			return osiApproved;
+		}
+
+		public void setOsiApproved(boolean osiApproved) {
+			this.osiApproved = osiApproved;
+		}
+
+		public String getLicenseName() {
+			return licenseName;
+		}
+
+		public void setLicenseName(String licenseName) {
+			this.licenseName = licenseName;
+		}
+	}
+	
+	ArrayList<ListedSpdxLicense> listedLicenses = new ArrayList<ListedSpdxLicense>();
+	
+	private int currentRefNumber = 1;
+
+	String version;
+	String releaseDate;
+
+	public LicenseTOCJSONFile(String version, String releaseDate) {
+		this.version = version;
+		this.releaseDate = releaseDate;
+	}
+
+	public void addLicense(SpdxListedLicense license, String licHTMLReference) {
+		listedLicenses.add(new ListedSpdxLicense(licHTMLReference, String.valueOf(this.currentRefNumber), 
+				license.getLicenseId(), license.isOsiApproved(), license.getName()));
+		currentRefNumber++;
+	}
+
+	public void writeToFile(File jsonFile) throws IOException {
+		FileWriter writer = null;
+		if (!jsonFile.exists()) {
+			if (!jsonFile.createNewFile()) {
+				throw(new IOException("Can not create new file "+jsonFile.getName()));
+			}
+		}
+		try {
+			JSONObject jsonObject = new JSONObject();
+			jsonObject.put("version", version);
+			jsonObject.put("releaseDate", releaseDate);
+			JSONArray licensesList = new JSONArray();
+			for (ListedSpdxLicense license : listedLicenses) {
+				JSONObject licenseJSON = new JSONObject();
+				licenseJSON.put("reference", license.getReference());
+				licenseJSON.put("referenceNumber", license.getRefNumber());
+				licenseJSON.put("id", license.getLicenseId());
+				licenseJSON.put("osiApproved", license.getOsiApproved());
+				licenseJSON.put("name", license.getLicenseName());
+				licensesList.add(licenseJSON);
+			}
+			jsonObject.put("licenses", licensesList);
+			writer = new FileWriter(jsonFile);
+			writer.write(jsonObject.toJSONString());
+		} finally {
+			if (writer != null) {
+				writer.close();
+			}
+		}
+	}
+}

--- a/src/org/spdx/tools/LicenseRDFAGenerator.java
+++ b/src/org/spdx/tools/LicenseRDFAGenerator.java
@@ -29,6 +29,7 @@ import org.spdx.compare.LicenseCompareHelper;
 import org.spdx.html.ExceptionHtml;
 import org.spdx.html.ExceptionHtmlToc;
 import org.spdx.html.LicenseHTMLFile;
+import org.spdx.html.LicenseTOCJSONFile;
 import org.spdx.html.LicenseTOCHTMLFile;
 import org.spdx.licenseTemplate.LicenseTemplateRuleException;
 import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
@@ -82,7 +83,8 @@ public class LicenseRDFAGenerator {
 	static final String TEXT_FOLDER_NAME = "text";
 	static final String TEMPLATE_FOLDER_NAME = "template";
 	static final String HTML_FOLDER_NAME = "html";
-	static final String LICENSE_TOC_FILE_NAME = "index.html";
+	static final String LICENSE_TOC_JSON_FILE_NAME = "licenses.json";
+	static final String LICENSE_TOC_HTML_FILE_NAME = "index.html";
 	static final String EXCEPTION_TOC_FILE_NAME = "exceptions-index.html";
 	
 	/**
@@ -277,6 +279,7 @@ public class LicenseRDFAGenerator {
 			}
 		}
 	}
+
 	/**
 	 * Writes the index.html file and the individual license list HTML files
 	 * @param version License list version
@@ -298,7 +301,8 @@ public class LicenseRDFAGenerator {
 			File dir, File textFolder, File htmlFolder, File templateFolder) throws SpdxListedLicenseException, IOException, LicenseTemplateRuleException, MustacheException {
 		Charset utf8 = Charset.forName("UTF-8");
 		LicenseHTMLFile licHtml = new LicenseHTMLFile();
-		LicenseTOCHTMLFile tableOfContents = new LicenseTOCHTMLFile(version, releaseDate);
+		LicenseTOCJSONFile tableOfContentsJSON = new LicenseTOCJSONFile(version, releaseDate);
+		LicenseTOCHTMLFile tableOfContentsHTML = new LicenseTOCHTMLFile(version, releaseDate);
 		// Main page - License list
 		Iterator<SpdxListedLicense> licenseIter = licenseProvider.getLicenseIterator();
 		HashMap<String, String> addedLicIdTextMap = new HashMap<String, String>();
@@ -321,13 +325,14 @@ public class LicenseRDFAGenerator {
 				String licBaseHtmlFileName = formLicenseHTMLFileName(license.getLicenseId());
 				String licHtmlFileName = licBaseHtmlFileName + ".html";
 				String licHTMLReference = "./"+licHtmlFileName;
-				String tocHTMLReference = "./"+LICENSE_TOC_FILE_NAME;
+				String tocHTMLReference = "./"+LICENSE_TOC_HTML_FILE_NAME;
 				File licBaseHtmlFile = new File(dir.getPath()+File.separator+licBaseHtmlFileName);
 				// the base file is used for direct references from tools, the html is used for rendering by the website
 				licHtml.writeToFile(licBaseHtmlFile, tocHTMLReference);
 				File licHtmlFile = new File(dir.getPath()+File.separator+licHtmlFileName);
 				licHtml.writeToFile(licHtmlFile, tocHTMLReference);
-				tableOfContents.addLicense(license, licHTMLReference);
+				tableOfContentsJSON.addLicense(license, licHTMLReference);
+				tableOfContentsHTML.addLicense(license, licHTMLReference);
 				File textFile = new File(textFolder.getPath() + File.separator + licHtmlFileName + ".txt");
 				Files.write(license.getLicenseText(), textFile, utf8);
 				if (license.getStandardLicenseTemplate() != null && !license.getStandardLicenseTemplate().trim().isEmpty()) {
@@ -346,10 +351,10 @@ public class LicenseRDFAGenerator {
 			licHtml.setDeprecatedVersion(deprecatedLicense.getDeprecatedVersion());
 			String licHtmlFileName = formLicenseHTMLFileName(deprecatedLicense.getLicense().getLicenseId());
 			String licHTMLReference = "./"+licHtmlFileName;
-			String tocHTMLReference = "./"+LICENSE_TOC_FILE_NAME;
+			String tocHTMLReference = "./"+LICENSE_TOC_HTML_FILE_NAME;
 			File licHtmlFile = new File(dir.getPath()+File.separator+licHtmlFileName);
 			licHtml.writeToFile(licHtmlFile, tocHTMLReference);
-			tableOfContents.addDeprecatedLicense(deprecatedLicense, licHTMLReference);
+			tableOfContentsHTML.addDeprecatedLicense(deprecatedLicense, licHTMLReference);
 			File textFile = new File(textFolder.getPath() + File.separator + licHtmlFileName + ".txt");
 			Files.write(deprecatedLicense.getLicense().getLicenseText(), textFile, utf8);
 			if (deprecatedLicense.getLicense().getStandardLicenseTemplate() != null && !deprecatedLicense.getLicense().getStandardLicenseTemplate().trim().isEmpty()) {
@@ -360,8 +365,10 @@ public class LicenseRDFAGenerator {
 			Files.write(SpdxLicenseTemplateHelper.escapeHTML(deprecatedLicense.getLicense().getLicenseText()), htmlTextFile, utf8);
 
 		}
-		File tocHtmlFile = new File(dir.getPath()+File.separator+LICENSE_TOC_FILE_NAME);
-		tableOfContents.writeToFile(tocHtmlFile);
+		File tocJsonFile = new File(dir.getPath()+File.separator+LICENSE_TOC_JSON_FILE_NAME);
+		File tocHtmlFile = new File(dir.getPath()+File.separator+LICENSE_TOC_HTML_FILE_NAME);
+		tableOfContentsJSON.writeToFile(tocJsonFile);
+		tableOfContentsHTML.writeToFile(tocHtmlFile);
 	}
 
 	private static void writeCssFile(File dir) throws IOException {


### PR DESCRIPTION
This pull request adds a generator to add a `licenses.json` file containing information about SPDX license identifiers to spdx.org.

The work grew out of comments to rubygems/rubygems#1249.