### PR TITLE
Add a CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+Contributing
+============
+Thank you for your interest in `spdx-tools`. The project is open-source software, and bug reports, suggestions, and most especially patches are welcome.
+
+Issues
+------
+`spdx-tools` has a [project page on GitHub](https://github.com/spdx/tools/) where you can [create an issue](https://github.com/spdx/tools/issues/new) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make. You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
+
+Patches
+-------
+The source code for `spdx-tools` is hosted on [git.spdx.org](http://git.spdx.org) and mirrored at [github.com/spdx/tools](https://github.com/spdx/tools). Please review [open pull requests](https://github.com/spdx/tools/pulls) and [active branches](https://github.com/spdx/tools/branches) before committing time to a substantial revision. Work along similar lines may already be in progress.
+
+To submit a patch via GitHub, fork the repository, create a topic branch from `develop` for your work, and send a pull request when ready. If you would prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by e-mail.
+
+Licensing
+---------
+However you choose to contribute, please confirm in a comment to your pull request or by e-mail that you license your contributions under the terms of [the Apache License, Version 2.0](http://spdx.org/licenses/Apache-2.0).


### PR DESCRIPTION
This pull request adds a [GitHub-supported contributing guidelines file](https://github.com/blog/1184-contributing-guidelines) with hints and directions for project-related communication, patch submission, and contribution licensing.

@goneall, per [your comment](https://github.com/spdx/tools/issues/4#issuecomment-102706003) on the default branch in spdx/tools#4, we will want to update CONTRIBUTING to request topic branches off of `master`, rather than `develop`, after you merge.