### PR TITLE
Support "_" in license IDs as documented.

### DIFF
--- a/src/org/spdx/rdfparser/SpdxRdfConstants.java
+++ b/src/org/spdx/rdfparser/SpdxRdfConstants.java
@@ -226,7 +226,7 @@ public interface SpdxRdfConstants {
 	public static String NON_STD_LICENSE_ID_PRENUM = "LicenseRef-";
 	public static Pattern LICENSE_ID_PATTERN_NUMERIC = 
 			Pattern.compile(NON_STD_LICENSE_ID_PRENUM+"(\\d+)$");	// Pattern for numeric only license IDs
-	static Pattern LICENSE_ID_PATTERN = Pattern.compile(NON_STD_LICENSE_ID_PRENUM+"([0-9a-zA-Z\\.\\-\\+]+)$");
+	static Pattern LICENSE_ID_PATTERN = Pattern.compile(NON_STD_LICENSE_ID_PRENUM+"([0-9a-zA-Z\\.\\-\\_\\+]+)$");
 	
 	// SPDX Element Reference format
 	public static String SPDX_ELEMENT_REF_PRENUM = "SPDXRef-";


### PR DESCRIPTION
Per org.spdx.rdfparser.SpdxVerificationHelper, lines 44-45, License IDs "must start with 'LicenseRef-'  	and [be] made up of the characters from the set 'a'-'z', 'A'-'Z', '0'-'9', '+', '_', '.', and '-'." However, the current LICENSE_ID_PATTERN does not allow the underscore character. This is a regression since the 1.1 API, where IDs with underscores did not fail verification.

