### PR TITLE
ISSUE-12 Allow Java 1.8 Maven Instances to Compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,18 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<profiles>
+  		<profile>
+    			<id>doclint-java8-disable</id>
+    			<activation>
+      				<jdk>[1.8,)</jdk>
+    			</activation>
+    			<properties>
+      				<javadoc.opts>-Xdoclint:none</javadoc.opts>
+    			</properties>
+  		</profile>
+	</profiles>
+
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<testSourceDirectory>Test</testSourceDirectory>
@@ -246,6 +258,9 @@
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
+						<configuration>
+            						<additionalparam>${javadoc.opts}</additionalparam>
+          					</configuration>
 						<goals>
 							<goal>jar</goal>
 						</goals>


### PR DESCRIPTION
Java 1.8 adds strict documentation rules as a default-enabled feature. Currently, SPDX-Tools fails this validation. This commit adds an argument to any maven runs where Maven is backed by Java 1.8 or newer, which turns off the build-failure part of this check. Violations are still printed to the build log

This has been tested against Java 1.7 and Java 1.8.

My contributions are licensed under the Apache 2.0 License as required for contributions to this project