### PR TITLE
Remove Restricted Package Use and Begin Switching to Standard Library Methods

### DIFF
--- a/Test/org/spdx/rdfparser/license/TestLicenseInfoFactory.java
+++ b/Test/org/spdx/rdfparser/license/TestLicenseInfoFactory.java
@@ -16,7 +16,9 @@
 */
 package org.spdx.rdfparser.license;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,19 +31,12 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.spdx.rdfparser.license.AnyLicenseInfo;
-import org.spdx.rdfparser.license.ConjunctiveLicenseSet;
-import org.spdx.rdfparser.license.DisjunctiveLicenseSet;
-import org.spdx.rdfparser.license.LicenseInfoFactory;
-import org.spdx.rdfparser.license.ExtractedLicenseInfo;
-import org.spdx.rdfparser.license.SpdxListedLicense;
-import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
+import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
 
-import sun.nio.cs.StandardCharsets;
-
+import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
@@ -53,7 +48,6 @@ import com.hp.hpl.jena.util.FileManager;
  * @author Source Auditor
  *
  */
-@SuppressWarnings("restriction")
 public class TestLicenseInfoFactory {
 	static final String[] NONSTD_IDS = new String[] {SpdxRdfConstants.NON_STD_LICENSE_ID_PRENUM+"1",
 		SpdxRdfConstants.NON_STD_LICENSE_ID_PRENUM+"2", SpdxRdfConstants.NON_STD_LICENSE_ID_PRENUM+"3",
@@ -330,7 +324,7 @@ public class TestLicenseInfoFactory {
 	 */
 	private String readTextFile(String filePath) throws IOException {
 		File file = new File(filePath);
-		List<String> lines = Files.readLines(file, new StandardCharsets().charsetForName("UTF-8"));
+        List<String> lines = Files.readLines(file, Charsets.UTF_8);
 		Iterator<String> iter = lines.iterator();
 		StringBuilder sb = new StringBuilder();
 		if (iter.hasNext()) {

--- a/src/org/spdx/compare/ExternalReferencesSheet.java
+++ b/src/org/spdx/compare/ExternalReferencesSheet.java
@@ -29,6 +29,8 @@ import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.model.ExternalDocumentRef;
 import org.spdx.spdxspreadsheet.AbstractSheet;
 
+import com.google.common.base.Objects;
+
 /**
  * Sheet that compares the external document references
  * @author Gary O'Neall
@@ -45,8 +47,8 @@ public class ExternalReferencesSheet extends AbstractSheet {
 		public int compare(ExternalDocumentRef o1, ExternalDocumentRef o2) {
 			if (o1 instanceof ExternalDocumentRef) {
 				if (o2 instanceof ExternalDocumentRef) {
-					ExternalDocumentRef r1 = (ExternalDocumentRef)o1;
-					ExternalDocumentRef r2 = (ExternalDocumentRef)o2;
+					ExternalDocumentRef r1 = o1;
+					ExternalDocumentRef r2 = o2;
 					int retval = r1.getSpdxDocumentNamespace().compareTo((r2.getSpdxDocumentNamespace()));
 					if (retval == 0) {
 						try {
@@ -156,7 +158,7 @@ public class ExternalReferencesSheet extends AbstractSheet {
 			for (int i = 0; i < externalRefs.length; i++) {
 				if (externalRefs[i].length > refIndexes[i]) {
 					ExternalDocumentRef compareRef = externalRefs[i][refIndexes[i]];
-					if (RdfModelHelper.equalsConsideringNull(nextRef.getSpdxDocumentNamespace(),
+                    if (Objects.equal(nextRef.getSpdxDocumentNamespace(),
 							compareRef.getSpdxDocumentNamespace()) &&
 							RdfModelHelper.equivalentConsideringNull(nextRef.getChecksum(), 
 									compareRef.getChecksum())) {

--- a/src/org/spdx/compare/FileCopyrightSheet.java
+++ b/src/org/spdx/compare/FileCopyrightSheet.java
@@ -17,8 +17,9 @@
 package org.spdx.compare;
 
 import org.apache.poi.ss.usermodel.Workbook;
-import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.model.SpdxFile;
+
+import com.google.common.base.Objects;
 
 /**
  * Sheet comparing file copyrights
@@ -43,7 +44,7 @@ public class FileCopyrightSheet extends AbstractFileCompareSheet {
 	@Override
 	boolean valuesMatch(SpdxComparer comparer, SpdxFile fileA, int docIndexA,
 			SpdxFile fileB, int docIndexB) throws SpdxCompareException {
-		return RdfModelHelper.equalsConsideringNull(fileA.getCopyrightText(), 
+        return Objects.equal(fileA.getCopyrightText(),
 				fileB.getCopyrightText());
 	}
 

--- a/src/org/spdx/rdfparser/RdfModelHelper.java
+++ b/src/org/spdx/rdfparser/RdfModelHelper.java
@@ -20,6 +20,8 @@ import java.util.HashSet;
 
 import org.spdx.rdfparser.model.IRdfModel;
 
+import com.google.common.base.Objects;
+
 /**
  * Static class containing helper methods for implementations of IRdfModel
  * @author Gary O'Neall
@@ -83,18 +85,19 @@ public final class RdfModelHelper {
 		}
 	}
 
-	/**
-	 * Compares to objects considering possible null values
-	 * @param o1
-	 * @param o2
-	 * @return
-	 */
-	public static boolean equalsConsideringNull(Object o1, Object o2) {
-		if (o1 == null) {
-			return (o2 == null);
-		} else {
-			return o1.equals(o2);
-		}
+	        /**
+     * Compares to objects considering possible null values
+     * 
+     * @param o1
+     *            The first object to compare
+     * @param o2
+     *            The second object to compare
+     * @return True if the objects are equal, false otherwise
+     * @deprecated Use {@link com.google.common.base.Objects#equal(Object, Object)} instead
+     */
+	@Deprecated
+    public static boolean equalsConsideringNull(Object o1, Object o2) {
+        return Objects.equal(o1, o2);
 	}
 
 	/**
@@ -118,8 +121,7 @@ public final class RdfModelHelper {
 		for (int i = 0; i < array1.length; i++) {
 			boolean found = false;
 			for (int j = 0; j < array2.length; j++) {
-				if (!foundIndexes.contains(j) &&
-						equalsConsideringNull(array1[i],array2[j])) {
+                if (!foundIndexes.contains(j) && Objects.equal(array1[i], array2[j])) {
 					found = true;
 					foundIndexes.add(j);
 					break;

--- a/src/org/spdx/rdfparser/license/LicenseException.java
+++ b/src/org/spdx/rdfparser/license/LicenseException.java
@@ -26,6 +26,7 @@ import org.spdx.rdfparser.RdfParserHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.model.IRdfModel;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -166,7 +167,8 @@ public class LicenseException implements IRdfModel  {
 	 * @return resource created from the model
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	public Resource createResource(IModelContainer modelContainer) throws InvalidSPDXAnalysisException {	
+	@Override
+    public Resource createResource(IModelContainer modelContainer) throws InvalidSPDXAnalysisException {	
 		if (this.model != null &&
 				this.exceptionNode != null &&
 				this.resource != null &&
@@ -432,7 +434,8 @@ public class LicenseException implements IRdfModel  {
 		}
 	}
 	
-	public LicenseException clone() {
+	@Override
+    public LicenseException clone() {
 		return new LicenseException(this.getLicenseExceptionId(), this.getName(), this.getLicenseExceptionText(),
 				this.seeAlso, this.comment, this.example);
 	}
@@ -472,7 +475,8 @@ public class LicenseException implements IRdfModel  {
 		}
 	}
 
-	public ArrayList<String> verify() {
+	@Override
+    public ArrayList<String> verify() {
 		ArrayList<String> retval = new ArrayList<String>();
 		if (this.getLicenseExceptionId() == null || this.getLicenseExceptionId().trim().isEmpty()) {
 			retval.add("Missing required license exception ID");
@@ -494,9 +498,9 @@ public class LicenseException implements IRdfModel  {
 		LicenseException lCompare = (LicenseException)compare;
 		return (LicenseCompareHelper.isLicenseTextEquivalent(this.licenseExceptionText,
 				lCompare.getLicenseExceptionText()) &&
-				RdfModelHelper.equalsConsideringNull(this.comment, lCompare.getComment()) &&
-				RdfModelHelper.equalsConsideringNull(this.example, lCompare.getExample()) &&
-				RdfModelHelper.equalsConsideringNull(this.name, lCompare.getName()) &&
+                Objects.equal(this.comment, lCompare.getComment()) &&
+                Objects.equal(this.example, lCompare.getExample()) &&
+                Objects.equal(this.name, lCompare.getName()) &&
 				RdfModelHelper.arraysEqual(this.seeAlso, lCompare.getSeeAlso()));
 	}
 }

--- a/src/org/spdx/rdfparser/license/SimpleLicensingInfo.java
+++ b/src/org/spdx/rdfparser/license/SimpleLicensingInfo.java
@@ -24,6 +24,7 @@ import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.model.IRdfModel;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Property;
@@ -342,13 +343,14 @@ public abstract class SimpleLicensingInfo extends AnyLicenseInfo {
 		return _createResource(type, null);
 	}
 	
-	public boolean equivalent(IRdfModel compare) {
+	@Override
+    public boolean equivalent(IRdfModel compare) {
 		if (!(compare instanceof SimpleLicensingInfo)) {
 			return false;
 		}
 		SimpleLicensingInfo sCompare = (SimpleLicensingInfo)compare;
-		return RdfModelHelper.equalsConsideringNull(this.comment, sCompare.getComment()) &&
-				RdfModelHelper.equalsConsideringNull(this.name, sCompare.getName()) &&
+        return Objects.equal(this.comment, sCompare.getComment()) &&
+                Objects.equal(this.name, sCompare.getName()) &&
 				RdfModelHelper.arraysEqual(this.seeAlso, sCompare.getSeeAlso());
 	}
 	

--- a/src/org/spdx/rdfparser/license/SpdxListedLicense.java
+++ b/src/org/spdx/rdfparser/license/SpdxListedLicense.java
@@ -20,10 +20,10 @@ import java.util.ArrayList;
 
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.model.IRdfModel;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Property;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -113,7 +113,7 @@ public class SpdxListedLicense extends License {
 		}
 		// For a listed license, if the ID's equal, it is considered equivalent
 		SpdxListedLicense sCompare = (SpdxListedLicense)compare;
-		return RdfModelHelper.equalsConsideringNull(this.licenseId, sCompare.getLicenseId());
+        return Objects.equal(this.licenseId, sCompare.getLicenseId());
 	}
 
 }

--- a/src/org/spdx/rdfparser/model/Annotation.java
+++ b/src/org/spdx/rdfparser/model/Annotation.java
@@ -22,10 +22,10 @@ import java.util.HashMap;
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.SpdxVerificationHelper;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -261,7 +261,8 @@ public class Annotation extends RdfModelObject implements Comparable<Annotation>
 		return null;
 	}
 
-	public Annotation clone() {
+	@Override
+    public Annotation clone() {
 		return new Annotation(this.annotator, this.annotationType, this.annotationDate, 
 				this.comment);
 	}
@@ -275,10 +276,9 @@ public class Annotation extends RdfModelObject implements Comparable<Annotation>
 			return false;
 		}
 		Annotation comp = (Annotation)o;
-		return (RdfModelHelper.equalsConsideringNull(annotator, comp.getAnnotator()) &&
-				RdfModelHelper.equalsConsideringNull(annotationType, comp.getAnnotationType()) &&
-				RdfModelHelper.equalsConsideringNull(comment, comp.getComment()) &&
-				RdfModelHelper.equalsConsideringNull(annotationDate, comp.getAnnotationDate()));
+        return (Objects.equal(annotator, comp.getAnnotator()) &&
+                Objects.equal(annotationType, comp.getAnnotationType()) &&
+                Objects.equal(comment, comp.getComment()) && Objects.equal(annotationDate, comp.getAnnotationDate()));
 	}
 	
 	/**

--- a/src/org/spdx/rdfparser/model/Checksum.java
+++ b/src/org/spdx/rdfparser/model/Checksum.java
@@ -22,11 +22,11 @@ import java.util.Hashtable;
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.RdfParserHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.SpdxVerificationHelper;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -276,8 +276,7 @@ public class Checksum extends RdfModelObject implements Comparable<Checksum> {
 			return false;
 		}
 		Checksum cksum = (Checksum)compare;
-		return (RdfModelHelper.equalsConsideringNull(this.algorithm, cksum.getAlgorithm()) &&
-				RdfModelHelper.equalsConsideringNull(this.checksumValue, cksum.getValue()));
+        return (Objects.equal(this.algorithm, cksum.getAlgorithm()) && Objects.equal(this.checksumValue, cksum.getValue()));
 	}
 	
 	@Override

--- a/src/org/spdx/rdfparser/model/DoapProject.java
+++ b/src/org/spdx/rdfparser/model/DoapProject.java
@@ -20,10 +20,10 @@ import java.util.ArrayList;
 
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.SpdxVerificationHelper;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -255,7 +255,6 @@ public class DoapProject extends RdfModelObject {
 			return false;
 		}
 		DoapProject comp = (DoapProject)compare;
-		return (RdfModelHelper.equalsConsideringNull(this.name, comp.getName()) &&
-				RdfModelHelper.equalsConsideringNull(this.homePage, comp.getHomePage()));
+        return (Objects.equal(this.name, comp.getName()) && Objects.equal(this.homePage, comp.getHomePage()));
 	}
 }

--- a/src/org/spdx/rdfparser/model/ExternalDocumentRef.java
+++ b/src/org/spdx/rdfparser/model/ExternalDocumentRef.java
@@ -26,6 +26,7 @@ import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.SpdxVerificationHelper;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -271,9 +272,9 @@ public class ExternalDocumentRef extends RdfModelObject implements Comparable<Ex
 		}
 		ExternalDocumentRef compref = (ExternalDocumentRef)compare;
 		try {
-			return (RdfModelHelper.equalsConsideringNull(this.spdxDocumentNamespace, compref.getSpdxDocumentNamespace())&&
-					RdfModelHelper.equivalentConsideringNull(this.checksum, compref.getChecksum()) &&
-					RdfModelHelper.equalsConsideringNull(this.externalDocumentId,  compref.getExternalDocumentId()));
+            return (Objects.equal(this.spdxDocumentNamespace, compref.getSpdxDocumentNamespace()) &&
+                    RdfModelHelper.equivalentConsideringNull(this.checksum, compref.getChecksum()) && Objects.equal(this.externalDocumentId,
+                    compref.getExternalDocumentId()));
 		} catch (InvalidSPDXAnalysisException e) {
 			logger.error("Invald SPDX Analysis exception comparing external document references: "+e.getMessage(),e);
 			return false;

--- a/src/org/spdx/rdfparser/model/ExternalSpdxElement.java
+++ b/src/org/spdx/rdfparser/model/ExternalSpdxElement.java
@@ -22,8 +22,9 @@ import java.util.regex.Matcher;
 
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
+
+import com.google.common.base.Objects;
 
 /**
  * This is an SPDX element which is in an external document.
@@ -81,7 +82,8 @@ public class ExternalSpdxElement extends SpdxElement {
 		return matcher.group(2);
 	}
 	
-	public String getUri(IModelContainer modelContainer) throws InvalidSPDXAnalysisException {
+	@Override
+    public String getUri(IModelContainer modelContainer) throws InvalidSPDXAnalysisException {
 		Matcher matcher = SpdxRdfConstants.EXTERNAL_ELEMENT_REF_PATTERN.matcher(this.getId());
 		if (!matcher.matches()) {
 			throw(new InvalidSPDXAnalysisException("Invalid id format for an external document reference.  Must be of the form ExternalSPDXRef:SPDXID"));
@@ -102,7 +104,7 @@ public class ExternalSpdxElement extends SpdxElement {
 		if (!super.equivalent(comp)) {
 			return false;
 		}
-		return (RdfModelHelper.equalsConsideringNull(this.getId(), comp.getId()));
+        return (Objects.equal(this.getId(), comp.getId()));
 	}
 	
 	@Override
@@ -140,7 +142,8 @@ public class ExternalSpdxElement extends SpdxElement {
 	/* (non-Javadoc)
 	 * @see org.spdx.rdfparser.model.RdfModelObject#populateModel()
 	 */
-	protected void populateModel() throws InvalidSPDXAnalysisException {
+	@Override
+    protected void populateModel() throws InvalidSPDXAnalysisException {
 		// Do nothing
 	}
 }

--- a/src/org/spdx/rdfparser/model/Relationship.java
+++ b/src/org/spdx/rdfparser/model/Relationship.java
@@ -22,9 +22,9 @@ import java.util.HashMap;
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -316,13 +316,11 @@ public class Relationship extends RdfModelObject implements Comparable<Relations
 			if (comp.getRelatedSpdxElement() != null) {
 				return false;
 			} else {
-				return (RdfModelHelper.equalsConsideringNull(relationshipType, comp.getRelationshipType()) &&
-				RdfModelHelper.equalsConsideringNull(comment, comp.getComment()));
+                return (Objects.equal(relationshipType, comp.getRelationshipType()) && Objects.equal(comment, comp.getComment()));
 			}
 		} else {
 			return (relatedSpdxElement.equivalent(comp.getRelatedSpdxElement(), false) &&	// Note - we don't want to test relationships since that may send us into an infinite loop
-					RdfModelHelper.equalsConsideringNull(relationshipType, comp.getRelationshipType()) &&
-					RdfModelHelper.equalsConsideringNull(comment, comp.getComment()));
+                    Objects.equal(relationshipType, comp.getRelationshipType()) && Objects.equal(comment, comp.getComment()));
 		}
 	}
 	/**

--- a/src/org/spdx/rdfparser/model/SpdxDocument.java
+++ b/src/org/spdx/rdfparser/model/SpdxDocument.java
@@ -29,6 +29,7 @@ import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.license.SpdxListedLicense;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -177,7 +178,8 @@ public class SpdxDocument extends SpdxElement {
 		return model.createResource(SpdxRdfConstants.SPDX_NAMESPACE + SpdxRdfConstants.CLASS_SPDX_DOCUMENT);
 	}
 	
-	protected void populateModel() throws InvalidSPDXAnalysisException {
+	@Override
+    protected void populateModel() throws InvalidSPDXAnalysisException {
 		super.populateModel();
 		setPropertyValue(SpdxRdfConstants.SPDX_NAMESPACE,
 				SpdxRdfConstants.PROP_SPDX_DATA_LICENSE, this.dataLicense);
@@ -461,12 +463,11 @@ public class SpdxDocument extends SpdxElement {
 		}
 		SpdxDocument comp = (SpdxDocument)o;
 		try {
-		return (RdfModelHelper.equalsConsideringNull(this.creationInfo, comp.getCreationInfo()) &&
-				RdfModelHelper.equalsConsideringNull(this.dataLicense, comp.getDataLicense()) &&
+            return (Objects.equal(this.creationInfo, comp.getCreationInfo()) &&
+                    Objects.equal(this.dataLicense, comp.getDataLicense()) &&
 				RdfModelHelper.arraysEquivalent(this.getExternalDocumentRefs(), comp.getExternalDocumentRefs()) &&
 				RdfModelHelper.arraysEqual(this.getExtractedLicenseInfos(), comp.getExtractedLicenseInfos()) &&
-				RdfModelHelper.arraysEqual(this.reviewers, comp.getReviewers()) &&
-				RdfModelHelper.equalsConsideringNull(this.specVersion, comp.getSpecVersion()));
+                    RdfModelHelper.arraysEqual(this.reviewers, comp.getReviewers()) && Objects.equal(this.specVersion, comp.getSpecVersion()));
 		} catch (InvalidSPDXAnalysisException ex) {
 			logger.error("Error testing for equivalent",ex);
 			return false;

--- a/src/org/spdx/rdfparser/model/SpdxElement.java
+++ b/src/org/spdx/rdfparser/model/SpdxElement.java
@@ -26,6 +26,7 @@ import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -113,7 +114,8 @@ public class SpdxElement extends RdfModelObject {
 		}
 	}
 	
-	protected void populateModel() throws InvalidSPDXAnalysisException {
+	@Override
+    protected void populateModel() throws InvalidSPDXAnalysisException {
 		if (this.resource != null) {
 			if (this.name != null) {
 				setPropertyValue(SpdxRdfConstants.SPDX_NAMESPACE, getNamePropertyName(), name);
@@ -406,9 +408,8 @@ public class SpdxElement extends RdfModelObject {
 		if (testRelationships && !RdfModelHelper.arraysEquivalent(comp.getRelationships(), this.getRelationships())) {
 			return false;
 		}
-		return (RdfModelHelper.equalsConsideringNull(comp.getName(), this.getName()) &&
-				RdfModelHelper.arraysEquivalent(comp.getAnnotations(), this.getAnnotations()) &&
-				RdfModelHelper.equalsConsideringNull(comp.getComment(), this.getComment()));
+        return (Objects.equal(comp.getName(), this.getName()) &&
+                RdfModelHelper.arraysEquivalent(comp.getAnnotations(), this.getAnnotations()) && Objects.equal(comp.getComment(), this.getComment()));
 	}
 	
 	

--- a/src/org/spdx/rdfparser/model/SpdxFile.java
+++ b/src/org/spdx/rdfparser/model/SpdxFile.java
@@ -29,6 +29,7 @@ import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -566,7 +567,7 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 				RdfModelHelper.arraysEqual(this.fileContributors, comp.getFileContributors()) &&
 				RdfModelHelper.arraysEquivalent(this.artifactOf, comp.getArtifactOf()) &&
 				RdfModelHelper.arraysEquivalent(this.fileDependencies, comp.getFileDependencies()) &&
-				RdfModelHelper.equalsConsideringNull(this.noticeText, comp.getNoticeText()));
+				Objects.equal(this.noticeText, comp.getNoticeText()));
 	}
 	
 	protected Checksum[] cloneChecksum() {
@@ -602,7 +603,8 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 		return retval;
 	}
 	
-	public SpdxFile clone(HashMap<String, SpdxElement> clonedElementIds) {
+	@Override
+    public SpdxFile clone(HashMap<String, SpdxElement> clonedElementIds) {
 		if (clonedElementIds.containsKey(this.getId())) {
 			return (SpdxFile)clonedElementIds.get(this.getId());
 		}

--- a/src/org/spdx/rdfparser/model/SpdxItem.java
+++ b/src/org/spdx/rdfparser/model/SpdxItem.java
@@ -29,6 +29,7 @@ import org.spdx.rdfparser.license.SimpleLicensingInfo;
 import org.spdx.rdfparser.license.SpdxNoAssertionLicense;
 import org.spdx.rdfparser.license.SpdxNoneLicense;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -104,7 +105,8 @@ public class SpdxItem extends SpdxElement {
 	/* (non-Javadoc)
 	 * @see org.spdx.rdfparser.model.RdfModelObject#populateModel()
 	 */
-	protected void populateModel() throws InvalidSPDXAnalysisException {
+	@Override
+    protected void populateModel() throws InvalidSPDXAnalysisException {
 		super.populateModel();
 		if (this.resource != null) {
 			if (this.licenseConcluded != null) {
@@ -255,10 +257,10 @@ public class SpdxItem extends SpdxElement {
 		if (!super.equivalent(comp)) {
 			return false;
 		}
-		return (RdfModelHelper.equalsConsideringNull(this.copyrightText, comp.getCopyrightText()) &&
+		return (Objects.equal(this.copyrightText, comp.getCopyrightText()) &&
 				RdfModelHelper.equivalentConsideringNull(this.licenseConcluded, comp.getLicenseConcluded()) &&
 				RdfModelHelper.arraysEquivalent(this.licenseInfoFromFiles, comp.getLicenseInfoFromFiles()) &&
-				RdfModelHelper.equalsConsideringNull(this.licenseComments, comp.getLicenseComments()));
+				Objects.equal(this.licenseComments, comp.getLicenseComments()));
 	}
 	
 	protected AnyLicenseInfo cloneLicenseConcluded() {
@@ -285,7 +287,8 @@ public class SpdxItem extends SpdxElement {
 		return clone(new HashMap<String, SpdxElement>());
 	}
 	
-	public SpdxItem clone(HashMap<String, SpdxElement> clonedElementIds) {
+	@Override
+    public SpdxItem clone(HashMap<String, SpdxElement> clonedElementIds) {
 		if (clonedElementIds.containsKey(this.getId())) {
 			return (SpdxItem)clonedElementIds.get(this.getId());
 		}

--- a/src/org/spdx/rdfparser/model/SpdxPackage.java
+++ b/src/org/spdx/rdfparser/model/SpdxPackage.java
@@ -30,6 +30,7 @@ import org.spdx.rdfparser.SpdxVerificationHelper;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 
+import com.google.common.base.Objects;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -630,23 +631,24 @@ public class SpdxPackage extends SpdxItem implements SpdxRdfConstants, Comparabl
 			}
 		return (RdfModelHelper.equivalentConsideringNull(this.licenseDeclared, comp.getLicenseDeclared()) &&
 				RdfModelHelper.arraysEquivalent(this.checksums, comp.getChecksums()) &&
-				RdfModelHelper.equalsConsideringNull(this.description, comp.getDescription()) &&
-				RdfModelHelper.equalsConsideringNull(this.downloadLocation, comp.getDownloadLocation()) &&
+				Objects.equal(this.description, comp.getDescription()) &&
+				Objects.equal(this.downloadLocation, comp.getDownloadLocation()) &&
 				RdfModelHelper.arraysEquivalent(this.files, comp.getFiles()) &&
-				RdfModelHelper.equalsConsideringNull(this.homepage, comp.getHomepage()) &&
-				RdfModelHelper.equalsConsideringNull(this.originator, comp.getOriginator()) &&
-				RdfModelHelper.equalsConsideringNull(this.packageFileName, comp.getPackageFileName()) &&
-				RdfModelHelper.equalsConsideringNull(this.sourceInfo, comp.getSourceInfo()) &&
-				RdfModelHelper.equalsConsideringNull(this.summary, comp.getSummary()) &&
-				RdfModelHelper.equalsConsideringNull(this.supplier, comp.getSupplier()) &&
-				RdfModelHelper.equalsConsideringNull(this.versionInfo, comp.getVersionInfo()));
+				Objects.equal(this.homepage, comp.getHomepage()) &&
+				Objects.equal(this.originator, comp.getOriginator()) &&
+				Objects.equal(this.packageFileName, comp.getPackageFileName()) &&
+				Objects.equal(this.sourceInfo, comp.getSourceInfo()) &&
+				Objects.equal(this.summary, comp.getSummary()) &&
+				Objects.equal(this.supplier, comp.getSupplier()) &&
+				Objects.equal(this.versionInfo, comp.getVersionInfo()));
 		} catch (InvalidSPDXAnalysisException e) {
 			logger.error("Invalid analysis exception on comparing equivalent: "+e.getMessage(),e);
 			return false;
 		}
 	}
 	
-	public SpdxPackage clone(HashMap<String, SpdxElement> clonedElementIds) {
+	@Override
+    public SpdxPackage clone(HashMap<String, SpdxElement> clonedElementIds) {
 		if (clonedElementIds.containsKey(this.getId())) {
 			return (SpdxPackage)clonedElementIds.get(this.getId());
 		}


### PR DESCRIPTION
This request includes the replacement of a reference to StandardCharsets, which exists within a restricted package, with the Guava library equivalent. In addition, it replaces uses of a custom null-handling equals with an equivalent Guava method (the original method is deprecated and remains for backwards compatibility, at least for a couple releases)

My contributions are licensed under the Apache 2.0 license as required for contributions to this project