### PR TITLE
Replace All Direct References to HashMap with Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /release.properties
 /pom.xml.releaseBackup
 SPDXParser.spdx
+maven-eclipse.xml

--- a/Test/org/spdx/compare/LicenseCompareHelperTest.java
+++ b/Test/org/spdx/compare/LicenseCompareHelperTest.java
@@ -17,9 +17,10 @@
 */
 package org.spdx.compare;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -28,11 +29,13 @@ import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ConjunctiveLicenseSet;
 import org.spdx.rdfparser.license.DisjunctiveLicenseSet;
-import org.spdx.rdfparser.license.LicenseInfoFactory;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
-import org.spdx.rdfparser.license.SpdxNoneLicense;
+import org.spdx.rdfparser.license.LicenseInfoFactory;
 import org.spdx.rdfparser.license.SpdxListedLicense;
 import org.spdx.rdfparser.license.SpdxNoAssertionLicense;
+import org.spdx.rdfparser.license.SpdxNoneLicense;
+
+import com.google.common.collect.Maps;
 
 /**
  * @author Gary O'Neall
@@ -170,7 +173,7 @@ public class LicenseCompareHelperTest {
 
 	@Test
 	public void testLicenseEqualsStdLicense() throws InvalidSPDXAnalysisException, SpdxCompareException {
-		HashMap<String, String> xlation = new HashMap<String, String>();
+		Map<String, String> xlation = Maps.newHashMap();
 		String licName = "name";
 		String licId = "ID1";
 		String licText = "Text";
@@ -204,7 +207,7 @@ public class LicenseCompareHelperTest {
 	
 	@Test
 	public void testLicenseEqualsNonStdLicense() throws InvalidSPDXAnalysisException, SpdxCompareException {
-		HashMap<String, String> xlation = new HashMap<String, String>();
+		Map<String, String> xlation = Maps.newHashMap();
 		String licId = "ID1";
 		String licText = "Text";
 
@@ -238,7 +241,7 @@ public class LicenseCompareHelperTest {
 		String licId4 = "id4";
 		String licId5 = "id5";
 		String licId6 = "id6";
-		HashMap<String, String> xlation = new HashMap<String, String>();
+		Map<String, String> xlation = Maps.newHashMap();
 		ExtractedLicenseInfo lic1 = new ExtractedLicenseInfo(licId1, licText);
 		ExtractedLicenseInfo lic2 = new ExtractedLicenseInfo(licId2, licText);
 		ExtractedLicenseInfo lic3 = new ExtractedLicenseInfo(licId3, licText);
@@ -283,7 +286,7 @@ public class LicenseCompareHelperTest {
 		String licId4 = "id4";
 		String licId5 = "id5";
 		String licId6 = "id6";
-		HashMap<String, String> xlation = new HashMap<String, String>();
+		Map<String, String> xlation = Maps.newHashMap();
 		ExtractedLicenseInfo lic1 = new ExtractedLicenseInfo(licId1, licText);
 		ExtractedLicenseInfo lic2 = new ExtractedLicenseInfo(licId2, licText);
 		ExtractedLicenseInfo lic3 = new ExtractedLicenseInfo(licId3, licText);
@@ -401,7 +404,7 @@ public class LicenseCompareHelperTest {
 		String licId4 = "id4";
 		String licId5 = "id5";
 		String licId6 = "id6";
-		HashMap<String, String> xlation = new HashMap<String, String>();
+		Map<String, String> xlation = Maps.newHashMap();
 		ExtractedLicenseInfo lic1 = new ExtractedLicenseInfo(licId1, licText);
 		ExtractedLicenseInfo lic2 = new ExtractedLicenseInfo(licId2, licText);
 		ExtractedLicenseInfo lic3 = new ExtractedLicenseInfo(licId3, licText);
@@ -440,7 +443,7 @@ public class LicenseCompareHelperTest {
 		String licId4 = "id4";
 		String licId5 = "id5";
 		String licId6 = "id6";
-		HashMap<String, String> xlation = new HashMap<String, String>();
+		Map<String, String> xlation = Maps.newHashMap();
 		ExtractedLicenseInfo lic1 = new ExtractedLicenseInfo(licId1, licText);
 		ExtractedLicenseInfo lic2 = new ExtractedLicenseInfo(licId2, licText);
 		ExtractedLicenseInfo lic3 = new ExtractedLicenseInfo(licId3, licText);
@@ -477,7 +480,7 @@ public class LicenseCompareHelperTest {
 		SpdxNoAssertionLicense lic2 = new SpdxNoAssertionLicense();
 		SpdxNoneLicense lic3 = new SpdxNoneLicense();
 		SpdxNoneLicense lic4 = new SpdxNoneLicense();
-		HashMap<String, String> xlationMap = new HashMap<String, String>();
+		Map<String, String> xlationMap = Maps.newHashMap();
 		assertTrue(LicenseCompareHelper.isLicenseEqual(lic1, lic2, xlationMap));
 		assertFalse(LicenseCompareHelper.isLicenseEqual(lic1, lic3, xlationMap));
 	}	
@@ -488,7 +491,7 @@ public class LicenseCompareHelperTest {
 		SpdxNoAssertionLicense lic2 = new SpdxNoAssertionLicense();
 		SpdxNoneLicense lic3 = new SpdxNoneLicense();
 		SpdxNoneLicense lic4 = new SpdxNoneLicense();
-		HashMap<String, String> xlationMap = new HashMap<String, String>();
+		Map<String, String> xlationMap = Maps.newHashMap();
 		assertTrue(LicenseCompareHelper.isLicenseEqual(lic3, lic4, xlationMap));
 		assertFalse(LicenseCompareHelper.isLicenseEqual(lic4, lic2, xlationMap));
 	}	

--- a/Test/org/spdx/compare/SpdxComparerTest.java
+++ b/Test/org/spdx/compare/SpdxComparerTest.java
@@ -17,18 +17,20 @@
 */
 package org.spdx.compare;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.spdx.compare.SpdxLicenseDifference;
 import org.spdx.compare.SpdxComparer.SPDXReviewDifference;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SPDXCreatorInformation;
@@ -41,27 +43,29 @@ import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ConjunctiveLicenseSet;
 import org.spdx.rdfparser.license.DisjunctiveLicenseSet;
 import org.spdx.rdfparser.license.DuplicateExtractedLicenseIdException;
+import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.license.License;
 import org.spdx.rdfparser.license.LicenseInfoFactory;
-import org.spdx.rdfparser.license.ExtractedLicenseInfo;
-import org.spdx.rdfparser.license.SpdxNoneLicense;
 import org.spdx.rdfparser.license.SpdxListedLicense;
 import org.spdx.rdfparser.license.SpdxNoAssertionLicense;
+import org.spdx.rdfparser.license.SpdxNoneLicense;
 import org.spdx.rdfparser.model.Annotation;
+import org.spdx.rdfparser.model.Annotation.AnnotationType;
 import org.spdx.rdfparser.model.Checksum;
+import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 import org.spdx.rdfparser.model.ExternalDocumentRef;
 import org.spdx.rdfparser.model.Relationship;
+import org.spdx.rdfparser.model.Relationship.RelationshipType;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxElement;
 import org.spdx.rdfparser.model.SpdxFile;
+import org.spdx.rdfparser.model.SpdxFile.FileType;
 import org.spdx.rdfparser.model.SpdxItem;
 import org.spdx.rdfparser.model.SpdxPackage;
-import org.spdx.rdfparser.model.Annotation.AnnotationType;
-import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
-import org.spdx.rdfparser.model.Relationship.RelationshipType;
-import org.spdx.rdfparser.model.SpdxFile.FileType;
 import org.spdx.rdfparser.model.UnitTestHelper;
 import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
+
+import com.google.common.collect.Maps;
 
 
 /**
@@ -96,7 +100,7 @@ public class SpdxComparerTest {
 	private static final String NAMEA = "NameA";
 	private static final String NAMEB = "NameB";
 	private static final String NAMEC = "NameC";
-	private static final HashMap<String, String> LICENSE_XLATION_MAP = new HashMap<String, String>();
+	private static final Map<String, String> LICENSE_XLATION_MAP = Maps.newHashMap();
 	private static final AnyLicenseInfo LICENSE_DECLAREDA = LICENSEA2;
 	private static final AnyLicenseInfo LICENSE_DECLAREDB = LICENSEB2;
 	private static final String ORIGINATORA = "Organization: OrgA";
@@ -325,7 +329,7 @@ public class SpdxComparerTest {
 		ExtractedLicenseInfo[] extractedInfos1 = doc1.getExtractedLicenseInfos();
 		ExtractedLicenseInfo[] extractedInfos2 = doc2.getExtractedLicenseInfos();
 		
-		HashMap<Integer, Integer> xlateDoc1ToDoc2LicId = createLicIdXlation(extractedInfos1, extractedInfos2);
+		Map<Integer, Integer> xlateDoc1ToDoc2LicId = createLicIdXlation(extractedInfos1, extractedInfos2);
 		
 		//Standard License
 		SpdxListedLicense lic1 = LicenseInfoFactory.getListedLicenseById(STD_LIC_ID_CC0);
@@ -458,10 +462,10 @@ public class SpdxComparerTest {
 	 * @param licInfos2
 	 * @return
 	 */
-	private HashMap<Integer, Integer> createLicIdXlation(
+	private Map<Integer, Integer> createLicIdXlation(
 			ExtractedLicenseInfo[] licInfos1,
 			ExtractedLicenseInfo[] licInfos2) {
-		HashMap<Integer, Integer> retval = new HashMap<Integer, Integer>();
+		Map<Integer, Integer> retval = Maps.newHashMap();
 		for (int i = 0;i < licInfos1.length; i++) {
 			boolean found = false;
 			for (int j = 0; j < licInfos2.length; j++) {

--- a/Test/org/spdx/compare/SpdxFileComparerTest.java
+++ b/Test/org/spdx/compare/SpdxFileComparerTest.java
@@ -17,15 +17,16 @@
 */
 package org.spdx.compare;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.spdx.rdfparser.model.DoapProject;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxDocumentContainer;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
@@ -34,11 +35,14 @@ import org.spdx.rdfparser.license.LicenseInfoFactory;
 import org.spdx.rdfparser.model.Annotation;
 import org.spdx.rdfparser.model.Checksum;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
+import org.spdx.rdfparser.model.DoapProject;
 import org.spdx.rdfparser.model.Relationship;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxFile.FileType;
 import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
+
+import com.google.common.collect.Maps;
 
 /**
  * @author Gary O'Neall
@@ -49,8 +53,7 @@ public class SpdxFileComparerTest {
 	static final String TEST_RDF_FILE_PATH = "TestFiles"+File.separator+"SPDXRdfExample.rdf";
 	private static final String STD_LIC_ID_CC0 = "CC-BY-1.0";
 	private static final String STD_LIC_ID_MPL11 = "MPL-1.1";
-	HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> LICENSE_XLATION = 
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>>();
+	Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> LICENSE_XLATION = Maps.newHashMap();
 	File testRDFFile;
 	SpdxDocument DOCA;
 	SpdxDocument DOCB;
@@ -67,13 +70,11 @@ public class SpdxFileComparerTest {
 		String uri2 = "http://doc/uri2";
 		SpdxDocumentContainer containerB = new SpdxDocumentContainer(uri2);
 		DOCB = containerB.getSpdxDocument();
-		HashMap<SpdxDocument, HashMap<String, String>> bmap = 
-				new HashMap<SpdxDocument, HashMap<String, String>>();
-		bmap.put(DOCB, new HashMap<String, String>());
+		Map<SpdxDocument, Map<String, String>> bmap = Maps.newHashMap();
+		bmap.put(DOCB, Maps.<String, String>newHashMap());
 		LICENSE_XLATION.put(DOCA, bmap);
-		HashMap<SpdxDocument, HashMap<String, String>> amap = 
-				new HashMap<SpdxDocument, HashMap<String, String>>();
-		amap.put(DOCA, new HashMap<String, String>());
+		Map<SpdxDocument, Map<String, String>> amap = Maps.newHashMap();
+		amap.put(DOCA, Maps.<String, String>newHashMap());
 		LICENSE_XLATION.put(DOCB, amap);
 	}
 	/**

--- a/Test/org/spdx/compare/SpdxItemComparerTest.java
+++ b/Test/org/spdx/compare/SpdxItemComparerTest.java
@@ -16,9 +16,11 @@
 */
 package org.spdx.compare;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -30,11 +32,13 @@ import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.model.Annotation;
 import org.spdx.rdfparser.model.Annotation.AnnotationType;
-import org.spdx.rdfparser.model.Relationship.RelationshipType;
 import org.spdx.rdfparser.model.Relationship;
+import org.spdx.rdfparser.model.Relationship.RelationshipType;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxElement;
 import org.spdx.rdfparser.model.SpdxItem;
+
+import com.google.common.collect.Maps;
 
 /**
  * @author Gary
@@ -58,7 +62,7 @@ public class SpdxItemComparerTest {
 	private static final AnyLicenseInfo LICENSE_CONCLUDEDA = LICENSEA1;
 	private static final AnyLicenseInfo LICENSE_CONCLUDEDB = LICENSEB1;
 	private static final String NAMEA = "NameA";
-	private static final HashMap<String, String> LICENSE_XLATION_MAPAB = new HashMap<String, String>();
+	private static final Map<String, String> LICENSE_XLATION_MAPAB = Maps.newHashMap();
 	
 	static {
 		LICENSE_XLATION_MAPAB.put("LicenseRef-1", "LicenseRef-4");
@@ -66,7 +70,7 @@ public class SpdxItemComparerTest {
 		LICENSE_XLATION_MAPAB.put("LicenseRef-3", "LicenseRef-6");
 	}
 	
-	private static final HashMap<String, String> LICENSE_XLATION_MAPBA = new HashMap<String, String>();
+	private static final Map<String, String> LICENSE_XLATION_MAPBA = Maps.newHashMap();
 	
 	static {
 		LICENSE_XLATION_MAPBA.put("LicenseRef-4", "LicenseRef-1");
@@ -74,8 +78,7 @@ public class SpdxItemComparerTest {
 		LICENSE_XLATION_MAPBA.put("LicenseRef-6", "LicenseRef-3");
 	}
 	
-	private final HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> LICENSE_XLATION_MAP = 
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>>();
+	private final Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> LICENSE_XLATION_MAP = Maps.newHashMap();
 
 	private SpdxDocument DOCA;
 	private SpdxDocument DOCB;
@@ -153,12 +156,10 @@ public class SpdxItemComparerTest {
 		String uri2 = "http://doc/uri2";
 		SpdxDocumentContainer containerB = new SpdxDocumentContainer(uri2);
 		DOCB = containerB.getSpdxDocument();
-		HashMap<SpdxDocument, HashMap<String, String>> bmap = 
-				new HashMap<SpdxDocument, HashMap<String, String>>();
+		Map<SpdxDocument, Map<String, String>> bmap = Maps.newHashMap();
 		bmap.put(DOCB, LICENSE_XLATION_MAPAB);
 		LICENSE_XLATION_MAP.put(DOCA, bmap);
-		HashMap<SpdxDocument, HashMap<String, String>> amap = 
-				new HashMap<SpdxDocument, HashMap<String, String>>();
+		Map<SpdxDocument, Map<String, String>> amap = Maps.newHashMap();
 		amap.put(DOCA, LICENSE_XLATION_MAPBA);
 		LICENSE_XLATION_MAP.put(DOCB, amap);
 	}

--- a/Test/org/spdx/compare/SpdxPackageComparerTest.java
+++ b/Test/org/spdx/compare/SpdxPackageComparerTest.java
@@ -16,9 +16,11 @@
 */
 package org.spdx.compare;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -30,16 +32,18 @@ import org.spdx.rdfparser.SpdxPackageVerificationCode;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.model.Annotation;
+import org.spdx.rdfparser.model.Annotation.AnnotationType;
 import org.spdx.rdfparser.model.Checksum;
-import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 import org.spdx.rdfparser.model.Relationship;
-import org.spdx.rdfparser.model.SpdxElement;
-import org.spdx.rdfparser.model.Annotation.AnnotationType;
 import org.spdx.rdfparser.model.Relationship.RelationshipType;
+import org.spdx.rdfparser.model.SpdxDocument;
+import org.spdx.rdfparser.model.SpdxElement;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxFile.FileType;
 import org.spdx.rdfparser.model.SpdxPackage;
+
+import com.google.common.collect.Maps;
 
 /**
  * @author Gary
@@ -89,7 +93,7 @@ public class SpdxPackageComparerTest {
 	private static final String VERSIONINFOB = "Version B";
 	private static final String SUPPLIERA = "Person: Supplier A";
 	private static final String SUPPLIERB = "Person: Supplier B";
-	private static final HashMap<String, String> LICENSE_XLATION_MAPAB = new HashMap<String, String>();
+	private static final Map<String, String> LICENSE_XLATION_MAPAB = Maps.newHashMap();
 	
 	static {
 		LICENSE_XLATION_MAPAB.put("LicenseRef-1", "LicenseRef-4");
@@ -97,7 +101,7 @@ public class SpdxPackageComparerTest {
 		LICENSE_XLATION_MAPAB.put("LicenseRef-3", "LicenseRef-6");
 	}
 	
-	private static final HashMap<String, String> LICENSE_XLATION_MAPBA = new HashMap<String, String>();
+	private static final Map<String, String> LICENSE_XLATION_MAPBA = Maps.newHashMap();
 	
 	static {
 		LICENSE_XLATION_MAPBA.put("LicenseRef-4", "LicenseRef-1");
@@ -105,8 +109,7 @@ public class SpdxPackageComparerTest {
 		LICENSE_XLATION_MAPBA.put("LicenseRef-6", "LicenseRef-3");
 	}
 	
-	private final HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> LICENSE_XLATION_MAP = 
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>>();
+	private final Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> LICENSE_XLATION_MAP = Maps.newHashMap();
 
 	private SpdxDocument DOCA;
 	private SpdxDocument DOCB;
@@ -252,12 +255,10 @@ public class SpdxPackageComparerTest {
 		String uri2 = "http://doc/uri2";
 		SpdxDocumentContainer containerB = new SpdxDocumentContainer(uri2);
 		DOCB = containerB.getSpdxDocument();
-		HashMap<SpdxDocument, HashMap<String, String>> bmap = 
-				new HashMap<SpdxDocument, HashMap<String, String>>();
+		Map<SpdxDocument, Map<String, String>> bmap = Maps.newHashMap();
 		bmap.put(DOCB, LICENSE_XLATION_MAPAB);
 		LICENSE_XLATION_MAP.put(DOCA, bmap);
-		HashMap<SpdxDocument, HashMap<String, String>> amap = 
-				new HashMap<SpdxDocument, HashMap<String, String>>();
+		Map<SpdxDocument, Map<String, String>> amap = Maps.newHashMap();
 		amap.put(DOCA, LICENSE_XLATION_MAPBA);
 		LICENSE_XLATION_MAP.put(DOCB, amap);
 	}

--- a/Test/org/spdx/html/TestMustache.java
+++ b/Test/org/spdx/html/TestMustache.java
@@ -17,21 +17,21 @@
 package org.spdx.html;
 
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.github.mustachejava.Mustache;
 import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
+import com.google.common.collect.Maps;
 
 /**
  * @author Gary O'Neall
@@ -59,7 +59,7 @@ public class TestMustache {
 	public void testMustache() throws MustacheException, IOException {
 		File root = new File("TestFiles");
 		DefaultMustacheFactory builder = new DefaultMustacheFactory(root);
-		Map<String, Object> context = new HashMap<String, Object>();
+		Map<String, Object> context = Maps.newHashMap();
 		context.put(TEST_FIELD1, TEST_RESULT1);
 		Mustache m = builder.compile("testSimpleTemplate.txt");
 		StringWriter writer = new StringWriter();

--- a/Test/org/spdx/merge/MergeToolTest.java
+++ b/Test/org/spdx/merge/MergeToolTest.java
@@ -16,12 +16,12 @@
 */
 package org.spdx.merge;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -30,13 +30,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.spdx.compare.LicenseCompareHelper;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.model.SpdxDocument;
-import org.spdx.rdfparser.SPDXDocumentFactory;
-import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
-import org.spdx.tools.MergeSpdxDocs;
+import org.spdx.rdfparser.model.SpdxDocument;
+import org.spdx.rdfparser.model.SpdxFile;
 
+import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 
 /**
@@ -129,10 +128,10 @@ public class MergeToolTest {
 	 * @param toLicenses
 	 * @return
 	 */
-	private HashMap<String, String> mapLicenseIds(
+	private Map<String, String> mapLicenseIds(
 			AnyLicenseInfo[] fromLicenses,
 			AnyLicenseInfo[] toLicenses) {
-		HashMap<String, String> retval = new HashMap<String, String>();
+		Map<String, String> retval = Maps.newHashMap();
 		for (AnyLicenseInfo fromLicense : fromLicenses) {
 			if (fromLicense instanceof ExtractedLicenseInfo) {
 				ExtractedLicenseInfo fromNonStdLicense = (ExtractedLicenseInfo)fromLicense;

--- a/Test/org/spdx/merge/SpdxLicenseMapperTest.java
+++ b/Test/org/spdx/merge/SpdxLicenseMapperTest.java
@@ -16,27 +16,32 @@
 */
 package org.spdx.merge;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.model.SpdxDocument;
-import org.spdx.rdfparser.model.SpdxPackage;
 import org.spdx.rdfparser.SPDXDocumentFactory;
-import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ConjunctiveLicenseSet;
 import org.spdx.rdfparser.license.DisjunctiveLicenseSet;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
+import org.spdx.rdfparser.model.SpdxDocument;
+import org.spdx.rdfparser.model.SpdxFile;
+import org.spdx.rdfparser.model.SpdxPackage;
 import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
+
+import com.google.common.collect.Maps;
 
 /**
  * @author Gang Ling
@@ -131,7 +136,9 @@ public class SpdxLicenseMapperTest {
 		}
 		boolean licMappered = false;
 		for(int j = 0; j < mappedLicsInFile.length; j++){
-			if(mappedLicsInFile[j].equals(clonedNonStdLic));
+			if(mappedLicsInFile[j].equals(clonedNonStdLic)) {
+                ;
+            }
 			licMappered = true;
 		}
 		if(!licMappered){
@@ -254,8 +261,8 @@ public class SpdxLicenseMapperTest {
 		ExtractedLicenseInfo clonedNonStdLic = (ExtractedLicenseInfo) subNonStdLics[0].clone();
 		mapper.mappingNewNonStdLic(doc1, doc3, clonedNonStdLic);
 		
-		HashMap<AnyLicenseInfo, AnyLicenseInfo> interalMap = mapper.foundInterMap(doc3);
-		HashMap<AnyLicenseInfo,AnyLicenseInfo> expected = new HashMap<AnyLicenseInfo, AnyLicenseInfo>();
+		Map<AnyLicenseInfo, AnyLicenseInfo> interalMap = mapper.foundInterMap(doc3);
+		Map<AnyLicenseInfo,AnyLicenseInfo> expected = Maps.newHashMap();
 		String NewNonStdLicId = doc1.getDocumentContainer().getNextLicenseRef();
 		clonedNonStdLic.setLicenseId(NewNonStdLicId);
 		expected.put(subNonStdLics[0], clonedNonStdLic);

--- a/Test/org/spdx/rdfparser/VerificationCodeGeneratorTest.java
+++ b/Test/org/spdx/rdfparser/VerificationCodeGeneratorTest.java
@@ -16,7 +16,8 @@
 */
 package org.spdx.rdfparser;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +40,7 @@ public class VerificationCodeGeneratorTest {
 		"TestFiles"+File.separator+"spdx-parser-source"+File.separator+"org"+File.separator+"spdx"+File.separator+"rdfparser"+File.separator+"DOAPProject.java",
 		"TestFiles"+File.separator+"spdx-parser-source"+File.separator+"org"+File.separator+"spdx"+File.separator+"rdfparser"+File.separator+"SPDXFile.java"
 	};
-	private static final Object SHA1_RESULT = "559f9215216045864ca5785d1892a00106cf0f6a";
+	private static final Object SHA1_RESULT = "8615f031775407c75a5153e9377fdd3faf163e1a";
 	
 	private static String[] SPDX_FILE_NAMES = new String[] {
 		"file/path/abc-not-skipped.java", "file/path/skipped.spdx", "file/path/not-skipped"

--- a/Test/org/spdx/rdfparser/model/ModelContainerForTest.java
+++ b/Test/org/spdx/rdfparser/model/ModelContainerForTest.java
@@ -16,11 +16,12 @@
 */
 package org.spdx.rdfparser.model;
 
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 import org.spdx.rdfparser.IModelContainer;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.rdf.model.Model;
 
 /**
@@ -34,8 +35,8 @@ public class ModelContainerForTest implements IModelContainer {
 	String namespace;
 	int nextRef = 1;
 	HashSet<String> elementRefs = new HashSet<String>();
-	HashMap<String, String> externalNamespaceToId = new HashMap<String, String>();
-	HashMap<String, String> externalIdToNamespace = new HashMap<String, String>();
+	Map<String, String> externalNamespaceToId = Maps.newHashMap();
+	Map<String, String> externalIdToNamespace = Maps.newHashMap();
 	/**
 	 * 
 	 */

--- a/TestFiles/spdx-parser-source/org/spdx/rdfparser/SPDXLicenseInfoFactory.java
+++ b/TestFiles/spdx-parser-source/org/spdx/rdfparser/SPDXLicenseInfoFactory.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
 import org.spdx.rdfparser.SpdxRdfConstants;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -87,7 +88,7 @@ public class SPDXLicenseInfoFactory {
 	
 static final HashSet<String> STANDARD_LICENSE_ID_SET = new HashSet<String>();
 	
-	static HashMap<String, SPDXStandardLicense> STANDARD_LICENSES = null;
+	static Map<String, SPDXStandardLicense> STANDARD_LICENSES = null;
 	
 	static {
 		loadStdLicenseIDs();		
@@ -255,7 +256,7 @@ static final HashSet<String> STANDARD_LICENSE_ID_SET = new HashSet<String>();
 	}
 	
 	static void loadStdLicenseIDs() {
-		STANDARD_LICENSES = new HashMap<String, SPDXStandardLicense>();
+		STANDARD_LICENSES = Maps.newHashMap();
 		try {
 			Model stdLicenseModel = getStandardLicenseModel();
 			Node p = stdLicenseModel.getProperty(SpdxRdfConstants.SPDX_NAMESPACE, SpdxRdfConstants.PROP_LICENSE_ID).asNode();

--- a/maven-eclipse.xml
+++ b/maven-eclipse.xml
@@ -1,0 +1,11 @@
+<project default="copy-resources">
+  <target name="init"/>
+  <target name="copy-resources" depends="init">
+    <copy todir="target/classes/resources" filtering="false">
+      <fileset dir="resources" includes="**/*" excludes="**/*.java"/>
+    </copy>
+    <copy todir="target/classes/META-INF" filtering="false">
+      <fileset dir="." includes="NOTICE|LICENSE|README.md|changelog" excludes="**/*.java"/>
+    </copy>
+  </target>
+</project>

--- a/src/org/spdx/compare/LicenseCompareHelper.java
+++ b/src/org/spdx/compare/LicenseCompareHelper.java
@@ -18,8 +18,8 @@
 package org.spdx.compare;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,10 +29,12 @@ import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ConjunctiveLicenseSet;
 import org.spdx.rdfparser.license.DisjunctiveLicenseSet;
+import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.license.LicenseInfoFactory;
 import org.spdx.rdfparser.license.LicenseSet;
-import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.license.SpdxListedLicense;
+
+import com.google.common.collect.Maps;
 
 /**
  * Primarily a static class of helper functions for comparing two SPDX licenses
@@ -51,7 +53,9 @@ public class LicenseCompareHelper {
 		SKIPPABLE_TOKENS.add("*");		SKIPPABLE_TOKENS.add("\"\"\"");
 		SKIPPABLE_TOKENS.add("=begin");	SKIPPABLE_TOKENS.add("=end");
 	}
-	protected static final HashMap<String, String> EQUIV_TOKENS = new HashMap<String, String>();
+	
+	protected static final Map<String, String> EQUIV_TOKENS = Maps.newHashMap();
+	
 	static {
 		//TODO: These should be moved to a property file
 		EQUIV_TOKENS.put("acknowledgement","acknowledgment");   EQUIV_TOKENS.put("acknowledgment","acknowledgement");   
@@ -252,7 +256,7 @@ public class LicenseCompareHelper {
 	 * @throws SpdxCompareException 
 	 */
 	public static boolean isLicenseEqual(AnyLicenseInfo license1,
-			AnyLicenseInfo license2, HashMap<String, String> xlationMap) throws SpdxCompareException {
+			AnyLicenseInfo license2, Map<String, String> xlationMap) throws SpdxCompareException {
 		if (license1 instanceof ConjunctiveLicenseSet) {
 			if (!(license2 instanceof ConjunctiveLicenseSet)) {
 				return false;
@@ -279,7 +283,9 @@ public class LicenseCompareHelper {
 				}
 				return xlatedLicenseId.equals(licenseid2);
 			}
-		} else return license1.equals(license2);
+		} else {
+            return license1.equals(license2);
+        }
 	}
 
 	/**
@@ -289,9 +295,7 @@ public class LicenseCompareHelper {
 	 * @return
 	 * @throws SpdxCompareException 
 	 */
-	private static boolean isLicenseSetsEqual(
-			LicenseSet license1,
-			LicenseSet license2, HashMap<String, String> xlationMap) throws SpdxCompareException {
+	private static boolean isLicenseSetsEqual(LicenseSet license1, LicenseSet license2, Map<String, String> xlationMap) throws SpdxCompareException {
 		// note - order does not matter
 		AnyLicenseInfo[] licenseInfos1 = license1.getMembers();
 		AnyLicenseInfo[] licenseInfos2 = license2.getMembers();

--- a/src/org/spdx/compare/SpdxComparer.java
+++ b/src/org/spdx/compare/SpdxComparer.java
@@ -20,14 +20,17 @@ package org.spdx.compare;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SPDXCreatorInformation;
+import org.spdx.rdfparser.SPDXReview;
+import org.spdx.rdfparser.SpdxPackageVerificationCode;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.model.Annotation;
@@ -40,8 +43,8 @@ import org.spdx.rdfparser.model.SpdxElement;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxItem;
 import org.spdx.rdfparser.model.SpdxPackage;
-import org.spdx.rdfparser.SPDXReview;
-import org.spdx.rdfparser.SpdxPackageVerificationCode;
+
+import com.google.common.collect.Maps;
 
 /**
  * Performs a comparison between two or more SPDX documents and holds the results of the comparison
@@ -176,14 +179,13 @@ public class SpdxComparer {
 	 * the comparison which do not contain some of the reviewers in the key document.  See the
 	 * implementation of compareReviewers for details
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, SPDXReview[]>> uniqueReviews = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, SPDXReview[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, SPDXReview[]>> uniqueReviews = Maps.newHashMap();
+	
 	/**
 	 * Holds a map of any SPDX documents which have reviewer differenes.  A reviewer difference
 	 * is an SPDXReview with the same reviewer name but a different reviewer date or comment
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, SPDXReviewDifference[]>> reviewerDifferences = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, SPDXReviewDifference[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, SPDXReviewDifference[]>> reviewerDifferences = Maps.newHashMap();
 	
 	// Extracted Licensing Info results
 	/**
@@ -192,23 +194,20 @@ public class SpdxComparer {
 	 * the comparison which do not contain some of the reviewers in the key document.  See the
 	 * implementation of compareReviewers for details
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, ExtractedLicenseInfo[]>> uniqueExtractedLicenses = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, ExtractedLicenseInfo[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, ExtractedLicenseInfo[]>> uniqueExtractedLicenses = Maps.newHashMap();
 	/**
 	 * Map of any SPDX documents that have extraced license infos with equivalent text but different comments, id's or other fields
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxLicenseDifference[]>> licenseDifferences = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxLicenseDifference[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, SpdxLicenseDifference[]>> licenseDifferences = Maps.newHashMap();
 	/**
 	 * Maps the license ID's for the extracted license infos of the documents being compared.  License ID's are mapped based on the text
 	 * being equivalent 
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> extractedLicenseIdMap = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>>();
+	private Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap = Maps.newHashMap();
 
 	private boolean creatorInformationEquals;
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, String[]>> uniqueCreators = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, String[]>>();
+	
+	private Map<SpdxDocument, Map<SpdxDocument, String[]>> uniqueCreators = Maps.newHashMap();
 	
 	// file compare results
 	/**
@@ -217,15 +216,13 @@ public class SpdxComparer {
 	 * the comparison which do not contain some of the files in the key document.  See the
 	 * implementation of compareFiles for details
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxFile[]>> uniqueFiles = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxFile[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, SpdxFile[]>> uniqueFiles = Maps.newHashMap();
 	
 	/**
 	 * Holds a map of any SPDX documents which have file differences.  A file difference
 	 * is an SPDXReview with the same filename name but a different file property
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxFileDifference[]>> fileDifferences = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxFileDifference[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, SpdxFileDifference[]>> fileDifferences = Maps.newHashMap();
 
 	// Package compare results
 	/**
@@ -234,24 +231,21 @@ public class SpdxComparer {
 	 * the comparison which do not contain some of the packages in the key document.  See the
 	 * implementation of comparePackages for details
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxPackage[]>> uniquePackages = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxPackage[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, SpdxPackage[]>> uniquePackages = Maps.newHashMap();
 	
 	/**
 	 * Map of package names to package comparisons
 	 */
-	private HashMap<String, SpdxPackageComparer> packageComparers = new HashMap<String, SpdxPackageComparer>();
+	private Map<String, SpdxPackageComparer> packageComparers = Maps.newHashMap();
+	
 	// Annotation comparison results
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, Annotation[]>> uniqueDocumentAnnotations = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, Annotation[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, Annotation[]>> uniqueDocumentAnnotations = Maps.newHashMap();
 
 	// Document Relationships comparison results
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, Relationship[]>> uniqueDocumentRelationships = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, Relationship[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, Relationship[]>> uniqueDocumentRelationships = Maps.newHashMap();
 
 	// External Document References comparison results
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, ExternalDocumentRef[]>> uniqueExternalDocumentRefs = 
-		new HashMap<SpdxDocument, HashMap<SpdxDocument, ExternalDocumentRef[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, ExternalDocumentRef[]>> uniqueExternalDocumentRefs = Maps.newHashMap();
 	
 	public SpdxComparer() {
 		
@@ -311,9 +305,9 @@ public class SpdxComparer {
 		// hashmap uniqueExternalDocumentRefs
 		for (int i = 0; i < spdxDocs.length; i++) {
 			ExternalDocumentRef[] externalDocRefsA = spdxDocs[i].getExternalDocumentRefs();
-			HashMap<SpdxDocument, ExternalDocumentRef[]> uniqueAMap = uniqueExternalDocumentRefs.get(spdxDocs[i]);
+			Map<SpdxDocument, ExternalDocumentRef[]> uniqueAMap = uniqueExternalDocumentRefs.get(spdxDocs[i]);
 			if (uniqueAMap == null) {
-				uniqueAMap = new HashMap<SpdxDocument, ExternalDocumentRef[]>();
+				uniqueAMap = Maps.newHashMap();
 				// We will put this into the hashmap at the end of this method if it is not empty
 			}
 			for (int j = 0; j < spdxDocs.length; j++) {
@@ -345,9 +339,9 @@ public class SpdxComparer {
 		// hashmap uniqueDocumentRelationships
 		for (int i = 0; i < spdxDocs.length; i++) {
 			Relationship[] relationshipsA = spdxDocs[i].getRelationships();
-			HashMap<SpdxDocument, Relationship[]> uniqueAMap = uniqueDocumentRelationships.get(spdxDocs[i]);
+			Map<SpdxDocument, Relationship[]> uniqueAMap = uniqueDocumentRelationships.get(spdxDocs[i]);
 			if (uniqueAMap == null) {
-				uniqueAMap = new HashMap<SpdxDocument, Relationship[]>();
+				uniqueAMap = Maps.newHashMap();
 				// We will put this into the hashmap at the end of this method if it is not empty
 			}
 			for (int j = 0; j < spdxDocs.length; j++) {
@@ -379,9 +373,9 @@ public class SpdxComparer {
 		// hashmap uniqueAnnotations
 		for (int i = 0; i < spdxDocs.length; i++) {
 			Annotation[] annotationsA = spdxDocs[i].getAnnotations();
-			HashMap<SpdxDocument, Annotation[]> uniqueAMap = uniqueDocumentAnnotations.get(spdxDocs[i]);
+			Map<SpdxDocument, Annotation[]> uniqueAMap = uniqueDocumentAnnotations.get(spdxDocs[i]);
 			if (uniqueAMap == null) {
-				uniqueAMap = new HashMap<SpdxDocument, Annotation[]>();
+				uniqueAMap = Maps.newHashMap();
 				// We will put this into the hashmap at the end of this method if it is not empty
 			}
 			for (int j = 0; j < spdxDocs.length; j++) {
@@ -418,16 +412,14 @@ public class SpdxComparer {
 			SpdxFile[] filesA = collectAllFiles(spdxDocs[i]);
 			// note - the file arrays MUST be sorted for the comparator methods to work
 			Arrays.sort(filesA);
-			HashMap<SpdxDocument, SpdxFile[]> uniqueAMap = 
-				this.uniqueFiles.get(spdxDocs[i]);
+			Map<SpdxDocument, SpdxFile[]> uniqueAMap = this.uniqueFiles.get(spdxDocs[i]);
 			if (uniqueAMap == null) {
-				uniqueAMap = new HashMap<SpdxDocument, SpdxFile[]>();
+				uniqueAMap = Maps.newHashMap();
 			}
 			// this map will be added to uniqueFiles at the end if we find anything
-			HashMap<SpdxDocument, SpdxFileDifference[]> diffMap = 
-				this.fileDifferences.get(spdxDocs[i]);
+			Map<SpdxDocument, SpdxFileDifference[]> diffMap = this.fileDifferences.get(spdxDocs[i]);
 			if (diffMap == null) {
-				diffMap = new HashMap<SpdxDocument, SpdxFileDifference[]>();
+				diffMap = Maps.newHashMap();
 			}
 			for (int j = 0; j < spdxDocs.length; j++) {
 				if (j == i) {
@@ -572,9 +564,9 @@ public class SpdxComparer {
 	 */
 	static SpdxFileDifference[] findFileDifferences(SpdxDocument docA, SpdxDocument docB,
 			SpdxFile[] filesA, SpdxFile[] filesB, 
-			HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> licenseIdXlationMap) throws SpdxCompareException {
+			Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> licenseIdXlationMap) throws SpdxCompareException {
 		
-		ArrayList<SpdxFileDifference> alRetval = new ArrayList<SpdxFileDifference>();
+		List<SpdxFileDifference> alRetval = new ArrayList<SpdxFileDifference>();
 		int aIndex = 0;
 		int bIndex = 0;
 		while (aIndex < filesA.length && bIndex < filesB.length) {
@@ -681,9 +673,9 @@ public class SpdxComparer {
 		for (int i = 0; i < spdxDocs.length; i++) {
 			SPDXCreatorInformation creatorInfoA = spdxDocs[i].getCreationInfo();
 			String[] creatorsA = creatorInfoA.getCreators();
-			HashMap<SpdxDocument, String[]> uniqueAMap = uniqueCreators.get(spdxDocs[i]);
+			Map<SpdxDocument, String[]> uniqueAMap = uniqueCreators.get(spdxDocs[i]);
 			if (uniqueAMap == null) {
-				uniqueAMap = new HashMap<SpdxDocument, String[]>();
+				uniqueAMap = Maps.newHashMap();
 				// We will put this into the hashmap at the end of this method if it is not empty
 			}
 			for (int j = 0; j < spdxDocs.length; j++) {
@@ -772,10 +764,9 @@ public class SpdxComparer {
 			// note - the package arrays MUST be sorted for the comparator methods to work
 			Arrays.sort(pkgsA);
 			addPackageComparers(spdxDocs[i], pkgsA, this.extractedLicenseIdMap);
-			HashMap<SpdxDocument, SpdxPackage[]> uniqueAMap = 
-				this.uniquePackages.get(spdxDocs[i]);
+			Map<SpdxDocument, SpdxPackage[]> uniqueAMap = this.uniquePackages.get(spdxDocs[i]);
 			if (uniqueAMap == null) {
-				uniqueAMap = new HashMap<SpdxDocument, SpdxPackage[]>();
+				uniqueAMap = Maps.newHashMap();
 			}
 			for (int j = 0; j < spdxDocs.length; j++) {
 				if (j == i) {
@@ -811,7 +802,7 @@ public class SpdxComparer {
 	 * @throws SpdxCompareException 
 	 */
 	private void addPackageComparers(SpdxDocument spdxDocument,
-			SpdxPackage[] pkgs, HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> extractedLicenseIdMap) throws SpdxCompareException {
+			SpdxPackage[] pkgs, Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap) throws SpdxCompareException {
 		for (int i = 0; i < pkgs.length; i++) {
 			SpdxPackageComparer mpc = this.packageComparers.get(pkgs[i].getName());
 			if (mpc == null) {
@@ -838,11 +829,11 @@ public class SpdxComparer {
 			AnyLicenseInfo license2) throws SpdxCompareException {
 		this.checkDocsIndex(doc1);
 		this.checkDocsIndex(doc2);
-		HashMap<SpdxDocument, HashMap<String, String>> hm = this.extractedLicenseIdMap.get(this.spdxDocs[doc1]);
+		Map<SpdxDocument, Map<String, String>> hm = this.extractedLicenseIdMap.get(this.spdxDocs[doc1]);
 		if (hm == null) {
 			throw(new SpdxCompareException("Compare License Error - Extracted license id map has not been initialized."));
 		}
-		HashMap<String, String> xlationMap = hm.get(this.spdxDocs[doc2]);
+		Map<String, String> xlationMap = hm.get(this.spdxDocs[doc2]);
 		if (xlationMap == null) {
 			throw(new SpdxCompareException("Compare License Exception - Extracted license id map has not been initialized."));
 		}
@@ -961,21 +952,18 @@ public class SpdxComparer {
 	private void compareExtractedLicenseInfos() throws InvalidSPDXAnalysisException, SpdxCompareException {
 		for (int i = 0; i < spdxDocs.length; i++) {
 			ExtractedLicenseInfo[] extractedLicensesA = spdxDocs[i].getExtractedLicenseInfos();
-			HashMap<SpdxDocument, ExtractedLicenseInfo[]> uniqueMap = 
-				new HashMap<SpdxDocument, ExtractedLicenseInfo[]>();
-			HashMap<SpdxDocument, SpdxLicenseDifference[]> differenceMap = 
-				new HashMap<SpdxDocument, SpdxLicenseDifference[]>();
-			HashMap<SpdxDocument, HashMap<String, String>> licenseIdMap = 
-				new HashMap<SpdxDocument, HashMap<String, String>>();
+			Map<SpdxDocument, ExtractedLicenseInfo[]> uniqueMap = Maps.newHashMap();
+				Map<SpdxDocument, SpdxLicenseDifference[]> differenceMap = Maps.newHashMap();
+				Map<SpdxDocument, Map<String, String>> licenseIdMap = Maps.newHashMap();
 
 			for (int j = 0; j < spdxDocs.length; j++) {
 				if (i == j) {
 					continue;	// no need to compare to ourself;
 				}
-				HashMap<String, String> idMap = new HashMap<String, String>();
-				ArrayList<SpdxLicenseDifference> alDifferences = new ArrayList<SpdxLicenseDifference>();
+				Map<String, String> idMap = Maps.newHashMap();
+				List<SpdxLicenseDifference> alDifferences = new ArrayList<SpdxLicenseDifference>();
 				ExtractedLicenseInfo[] extractedLicensesB = spdxDocs[j].getExtractedLicenseInfos();
-				ArrayList<ExtractedLicenseInfo> uniqueLicenses = new ArrayList<ExtractedLicenseInfo>();
+				List<ExtractedLicenseInfo> uniqueLicenses = new ArrayList<ExtractedLicenseInfo>();
 				compareLicenses(extractedLicensesA, extractedLicensesB,
 						idMap, alDifferences, uniqueLicenses);
 				// unique
@@ -1014,9 +1002,9 @@ public class SpdxComparer {
 	 */
 	private void compareLicenses(ExtractedLicenseInfo[] extractedLicensesA,
 			ExtractedLicenseInfo[] extractedLicensesB,
-			HashMap<String, String> idMap,
-			ArrayList<SpdxLicenseDifference> alDifferences,
-			ArrayList<ExtractedLicenseInfo> uniqueLicenses) {
+			Map<String, String> idMap,
+			List<SpdxLicenseDifference> alDifferences,
+			List<ExtractedLicenseInfo> uniqueLicenses) {
 		idMap.clear();
 		alDifferences.clear();
 		uniqueLicenses.clear();
@@ -1225,14 +1213,14 @@ public class SpdxComparer {
 		for (int i = 0; i < spdxDocs.length; i++) {
 			@SuppressWarnings("deprecation")
 			SPDXReview[] reviewA = spdxDocs[i].getReviewers();
-			HashMap<SpdxDocument, SPDXReview[]> uniqueAMap = uniqueReviews.get(spdxDocs[i]);
+			Map<SpdxDocument, SPDXReview[]> uniqueAMap = uniqueReviews.get(spdxDocs[i]);
 			if (uniqueAMap == null) {
-				uniqueAMap = new HashMap<SpdxDocument, SPDXReview[]>();
+				uniqueAMap = Maps.newHashMap();
 				// We will put this into the hashmap at the end of this method if it is not empty
 			}
-			HashMap<SpdxDocument, SPDXReviewDifference[]> diffMap = this.reviewerDifferences.get(this.spdxDocs[i]);
+			Map<SpdxDocument, SPDXReviewDifference[]> diffMap = this.reviewerDifferences.get(this.spdxDocs[i]);
 			if (diffMap == null) {
-				diffMap = new HashMap<SpdxDocument, SPDXReviewDifference[]>();
+				diffMap = Maps.newHashMap();
 				// We will put this into the hashmap at the end of this method if it is not empty
 			}
 			for (int j = 0; j < spdxDocs.length; j++) {
@@ -1447,10 +1435,10 @@ public class SpdxComparer {
 	 */
 	private boolean _isReviewersEqualNoCheck() {
 		// check for unique reviewers
-		Iterator<Entry<SpdxDocument, HashMap<SpdxDocument, SPDXReview[]>>> uniqueIter =
+		Iterator<Entry<SpdxDocument, Map<SpdxDocument, SPDXReview[]>>> uniqueIter =
 			this.uniqueReviews.entrySet().iterator();
 		while (uniqueIter.hasNext()) {
-			Entry <SpdxDocument, HashMap<SpdxDocument, SPDXReview[]>> entry = uniqueIter.next();
+			Entry <SpdxDocument, Map<SpdxDocument, SPDXReview[]>> entry = uniqueIter.next();
 			Iterator<Entry<SpdxDocument, SPDXReview[]>> entryIter = entry.getValue().entrySet().iterator();
 			while (entryIter.hasNext()) {
 				SPDXReview[] val = entryIter.next().getValue();
@@ -1460,7 +1448,7 @@ public class SpdxComparer {
 			}
 		}
 		// check differences
-		Iterator<Entry<SpdxDocument, HashMap<SpdxDocument, SPDXReviewDifference[]>>> diffIter = this.reviewerDifferences.entrySet().iterator();
+		Iterator<Entry<SpdxDocument, Map<SpdxDocument, SPDXReviewDifference[]>>> diffIter = this.reviewerDifferences.entrySet().iterator();
 		while (diffIter.hasNext()) {
 			Iterator<Entry<SpdxDocument, SPDXReviewDifference[]>> entryIter = diffIter.next().getValue().entrySet().iterator();
 			while(entryIter.hasNext()) {
@@ -1475,8 +1463,7 @@ public class SpdxComparer {
 	}
 	
 	private boolean _isExternalDcoumentRefsEqualsNoCheck() {
-		Iterator<Entry<SpdxDocument, HashMap<SpdxDocument, ExternalDocumentRef[]>>> iter = 
-				this.uniqueExternalDocumentRefs.entrySet().iterator();
+		Iterator<Entry<SpdxDocument, Map<SpdxDocument, ExternalDocumentRef[]>>> iter = this.uniqueExternalDocumentRefs.entrySet().iterator();
 		while (iter.hasNext()) {
 			Iterator<ExternalDocumentRef[]> docIterator = iter.next().getValue().values().iterator();
 			while (docIterator.hasNext()) {
@@ -1507,10 +1494,10 @@ public class SpdxComparer {
 	 */
 	private boolean _isExtractedLicensingInfoEqualsNoCheck() {
 		// check for unique extraced license infos
-		Iterator<Entry<SpdxDocument, HashMap<SpdxDocument, ExtractedLicenseInfo[]>>> uniqueIter = 
+		Iterator<Entry<SpdxDocument, Map<SpdxDocument, ExtractedLicenseInfo[]>>> uniqueIter = 
 			this.uniqueExtractedLicenses.entrySet().iterator();
 		while (uniqueIter.hasNext()) {
-			Entry<SpdxDocument, HashMap<SpdxDocument, ExtractedLicenseInfo[]>> entry = uniqueIter.next();
+			Entry<SpdxDocument, Map<SpdxDocument, ExtractedLicenseInfo[]>> entry = uniqueIter.next();
 			Iterator<Entry<SpdxDocument, ExtractedLicenseInfo[]>> entryIter = entry.getValue().entrySet().iterator();
 			while(entryIter.hasNext()) {
 				ExtractedLicenseInfo[] licenses = entryIter.next().getValue();
@@ -1520,7 +1507,7 @@ public class SpdxComparer {
 			}
 		}
 		// check differences
-		Iterator<Entry<SpdxDocument, HashMap<SpdxDocument,SpdxLicenseDifference[]>>> diffIterator = this.licenseDifferences.entrySet().iterator();
+		Iterator<Entry<SpdxDocument, Map<SpdxDocument,SpdxLicenseDifference[]>>> diffIterator = this.licenseDifferences.entrySet().iterator();
 		while (diffIterator.hasNext()) {
 			Iterator<Entry<SpdxDocument,SpdxLicenseDifference[]>> entryIter = diffIterator.next().getValue().entrySet().iterator();
 			while (entryIter.hasNext()) {
@@ -1546,7 +1533,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		checkDocsIndex(docindex1);
 		checkDocsIndex(docindex2);
-		HashMap<SpdxDocument, SPDXReview[]> uniques = this.uniqueReviews.get(spdxDocs[docindex1]);
+		Map<SpdxDocument, SPDXReview[]> uniques = this.uniqueReviews.get(spdxDocs[docindex1]);
 		if (uniques != null) {
 			SPDXReview[] retval = uniques.get(spdxDocs[docindex2]);
 			if (retval != null) {
@@ -1573,7 +1560,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		checkDocsIndex(docindex1);
 		checkDocsIndex(docindex2);
-		HashMap<SpdxDocument, SPDXReviewDifference[]> doc1Differences =
+		Map<SpdxDocument, SPDXReviewDifference[]> doc1Differences =
 			this.reviewerDifferences.get(spdxDocs[docindex1]);
 		if (doc1Differences == null) {
 			return new SPDXReviewDifference[0];
@@ -1598,7 +1585,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		checkDocsIndex(docIndexA);
 		checkDocsIndex(docIndexB);
-		HashMap<SpdxDocument, ExtractedLicenseInfo[]> uniques = this.uniqueExtractedLicenses.get(spdxDocs[docIndexA]);
+		Map<SpdxDocument, ExtractedLicenseInfo[]> uniques = this.uniqueExtractedLicenses.get(spdxDocs[docIndexA]);
 		if (uniques != null) {
 			ExtractedLicenseInfo[] retval = uniques.get(spdxDocs[docIndexB]);
 			if (retval != null) {
@@ -1624,7 +1611,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		checkDocsIndex(docIndexA);
 		checkDocsIndex(docIndexB);
-		HashMap<SpdxDocument, SpdxLicenseDifference[]> differences = this.licenseDifferences.get(spdxDocs[docIndexA]);
+		Map<SpdxDocument, SpdxLicenseDifference[]> differences = this.licenseDifferences.get(spdxDocs[docIndexA]);
 		if (differences != null) {
 			SpdxLicenseDifference[] retval = differences.get(spdxDocs[docIndexB]);
 			if (retval != null) {
@@ -1657,7 +1644,7 @@ public class SpdxComparer {
 	public String[] getUniqueCreators(int doc1index, int doc2index) throws SpdxCompareException {
 		this.checkDocsField();
 		this.checkInProgress();
-		HashMap<SpdxDocument, String[]> uniques = this.uniqueCreators.get(this.getSpdxDoc(doc1index));
+		Map<SpdxDocument, String[]> uniques = this.uniqueCreators.get(this.getSpdxDoc(doc1index));
 		if (uniques == null) {
 			return new String[0];
 		}
@@ -1702,8 +1689,7 @@ public class SpdxComparer {
 	 * @return
 	 */
 	private boolean _isDocumentAnnotationsEqualsNoCheck() {
-		Iterator<Entry<SpdxDocument, HashMap<SpdxDocument, Annotation[]>>> iter = 
-				this.uniqueDocumentAnnotations.entrySet().iterator();
+		Iterator<Entry<SpdxDocument, Map<SpdxDocument, Annotation[]>>> iter = this.uniqueDocumentAnnotations.entrySet().iterator();
 		while (iter.hasNext()) {
 			Iterator<Annotation[]> docIterator = iter.next().getValue().values().iterator();
 			while (docIterator.hasNext()) {
@@ -1728,8 +1714,7 @@ public class SpdxComparer {
 	 * @return
 	 */
 	private boolean _isDocumentRelationshipsEqualsNoCheck() {
-		Iterator<Entry<SpdxDocument, HashMap<SpdxDocument, Relationship[]>>> iter = 
-				this.uniqueDocumentRelationships.entrySet().iterator();
+		Iterator<Entry<SpdxDocument, Map<SpdxDocument, Relationship[]>>> iter = this.uniqueDocumentRelationships.entrySet().iterator();
 		while (iter.hasNext()) {
 			Iterator<Relationship[]> docIterator = iter.next().getValue().values().iterator();
 			while (docIterator.hasNext()) {
@@ -1759,8 +1744,7 @@ public class SpdxComparer {
 	 * @throws SpdxCompareException 
 	 */
 	private boolean _isPackagesEqualsNoCheck() throws SpdxCompareException {
-		Iterator<Entry<SpdxDocument, HashMap<SpdxDocument, SpdxPackage[]>>> iter = 
-				this.uniquePackages.entrySet().iterator();
+		Iterator<Entry<SpdxDocument, Map<SpdxDocument, SpdxPackage[]>>> iter = this.uniquePackages.entrySet().iterator();
 		while (iter.hasNext()) {
 			Iterator<SpdxPackage[]> docIterator = iter.next().getValue().values().iterator();
 			while (docIterator.hasNext()) {
@@ -1789,7 +1773,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		this.checkDocsIndex(docindex1);
 		this.checkDocsIndex(docindex2);
-		HashMap<SpdxDocument, SpdxFile[]> uniqueMap = this.uniqueFiles.get(this.spdxDocs[docindex1]);
+		Map<SpdxDocument, SpdxFile[]> uniqueMap = this.uniqueFiles.get(this.spdxDocs[docindex1]);
 		if (uniqueMap == null) {
 			return new SpdxFile[0];
 		}
@@ -1813,7 +1797,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		this.checkDocsIndex(docindex1);
 		this.checkDocsIndex(docindex2);
-		HashMap<SpdxDocument, SpdxFileDifference[]> uniqueMap = this.fileDifferences.get(this.spdxDocs[docindex1]);
+		Map<SpdxDocument, SpdxFileDifference[]> uniqueMap = this.fileDifferences.get(this.spdxDocs[docindex1]);
 		if (uniqueMap == null) {
 			return new SpdxFileDifference[0];
 		}
@@ -1836,7 +1820,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		this.checkDocsIndex(docindex1);
 		this.checkDocsIndex(docindex2);
-		HashMap<SpdxDocument, SpdxPackage[]> uniqueMap = this.uniquePackages.get(this.spdxDocs[docindex1]);
+		Map<SpdxDocument, SpdxPackage[]> uniqueMap = this.uniquePackages.get(this.spdxDocs[docindex1]);
 		if (uniqueMap == null) {
 			return new SpdxPackage[0];
 		}
@@ -1859,7 +1843,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		this.checkDocsIndex(docindex1);
 		this.checkDocsIndex(docindex2);
-		HashMap<SpdxDocument, ExternalDocumentRef[]> uniqueMap = this.uniqueExternalDocumentRefs.get(this.spdxDocs[docindex1]);
+		Map<SpdxDocument, ExternalDocumentRef[]> uniqueMap = this.uniqueExternalDocumentRefs.get(this.spdxDocs[docindex1]);
 		if (uniqueMap == null) {
 			return new ExternalDocumentRef[0];
 		}
@@ -1882,7 +1866,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		this.checkDocsIndex(docindex1);
 		this.checkDocsIndex(docindex2);
-		HashMap<SpdxDocument, Annotation[]> uniqueMap = this.uniqueDocumentAnnotations.get(this.spdxDocs[docindex1]);
+		Map<SpdxDocument, Annotation[]> uniqueMap = this.uniqueDocumentAnnotations.get(this.spdxDocs[docindex1]);
 		if (uniqueMap == null) {
 			return new Annotation[0];
 		}
@@ -1905,7 +1889,7 @@ public class SpdxComparer {
 		this.checkInProgress();
 		this.checkDocsIndex(docindex1);
 		this.checkDocsIndex(docindex2);
-		HashMap<SpdxDocument, Relationship[]> uniqueMap = this.uniqueDocumentRelationships.get(this.spdxDocs[docindex1]);
+		Map<SpdxDocument, Relationship[]> uniqueMap = this.uniqueDocumentRelationships.get(this.spdxDocs[docindex1]);
 		if (uniqueMap == null) {
 			return new Relationship[0];
 		}

--- a/src/org/spdx/compare/SpdxFileComparer.java
+++ b/src/org/spdx/compare/SpdxFileComparer.java
@@ -20,19 +20,21 @@ package org.spdx.compare;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.model.Annotation;
 import org.spdx.rdfparser.model.Checksum;
+import org.spdx.rdfparser.model.DoapProject;
 import org.spdx.rdfparser.model.Relationship;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxFile;
-import org.spdx.rdfparser.model.DoapProject;
 import org.spdx.rdfparser.model.SpdxItem;
+
+import com.google.common.collect.Maps;
 
 
 /**
@@ -53,14 +55,12 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	/**
 	 * Map of artfifactOfs found in one document but not another
 	 */
-	HashMap<SpdxDocument, HashMap<SpdxDocument, DoapProject[]>> uniqueArtifactOfs = 
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, DoapProject[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, DoapProject[]>> uniqueArtifactOfs = Maps.newHashMap();
 
 	/**
 	 *  Map of checksums found in one document but not another
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, Checksum[]>> uniqueChecksums =
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, Checksum[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, Checksum[]>> uniqueChecksums = Maps.newHashMap();
 
 	
 	/**
@@ -92,7 +92,7 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	private boolean typesEquals = true;
 
 	
-	public SpdxFileComparer(HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> extractedLicenseIdMap) {
+	public SpdxFileComparer(Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap) {
 		super(extractedLicenseIdMap);
 	}
 	
@@ -157,8 +157,7 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	private void compareNewFileChecksums(SpdxDocument spdxDocument,
 			Checksum[] checksums) throws SpdxCompareException {
 
-		HashMap<SpdxDocument, Checksum[]> docUniqueChecksums = 
-				new HashMap<SpdxDocument, Checksum[]>();
+		Map<SpdxDocument, Checksum[]> docUniqueChecksums = Maps.newHashMap();
 		this.uniqueChecksums.put(spdxDocument, docUniqueChecksums);
 		Iterator<Entry<SpdxDocument,SpdxItem>> iter = this.documentItem.entrySet().iterator();
 		while (iter.hasNext()) {
@@ -171,9 +170,9 @@ public class SpdxFileComparer extends SpdxItemComparer {
 					this.differenceFound = true;
 				}
 				docUniqueChecksums.put(entry.getKey(), uniqueChecksums);
-				HashMap<SpdxDocument, Checksum[]> compareUniqueChecksums = this.uniqueChecksums.get(entry.getKey());
+				Map<SpdxDocument, Checksum[]> compareUniqueChecksums = this.uniqueChecksums.get(entry.getKey());
 				if (compareUniqueChecksums == null) {
-					compareUniqueChecksums = new HashMap<SpdxDocument, Checksum[]>();
+					compareUniqueChecksums = Maps.newHashMap();
 					this.uniqueChecksums.put(entry.getKey(), compareUniqueChecksums);
 				}
 				uniqueChecksums = SpdxComparer.findUniqueChecksums(compareChecksums, checksums);
@@ -246,7 +245,7 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	public DoapProject[] getUniqueArtifactOf(SpdxDocument docA, SpdxDocument docB) throws SpdxCompareException {
 		checkInProgress();
 		checkCompareMade();
-		HashMap<SpdxDocument, DoapProject[]> unique = this.uniqueArtifactOfs.get(docA);
+		Map<SpdxDocument, DoapProject[]> unique = this.uniqueArtifactOfs.get(docA);
 		if (unique == null) {
 			return new DoapProject[0];
 		}
@@ -276,8 +275,7 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	 */
 	public Checksum[] getUniqueChecksums(SpdxDocument docA, SpdxDocument docB) throws SpdxCompareException {
 		checkInProgress();
-		HashMap<SpdxDocument, Checksum[]> uniqueMap = 
-				this.uniqueChecksums.get(docA);
+		Map<SpdxDocument, Checksum[]> uniqueMap = this.uniqueChecksums.get(docA);
 		if (uniqueMap == null) {
 			return new Checksum[0];
 		}
@@ -307,10 +305,9 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	 */
 	private void compareNewArtifactOf(SpdxDocument spdxDocument,
 			DoapProject[] artifactOfs) {
-		HashMap<SpdxDocument, DoapProject[]> uniqueDocArtifactOf = 
-				this.uniqueArtifactOfs.get(spdxDocument);
+		Map<SpdxDocument, DoapProject[]> uniqueDocArtifactOf = this.uniqueArtifactOfs.get(spdxDocument);
 		if (uniqueDocArtifactOf == null) {
-			uniqueDocArtifactOf = new HashMap<SpdxDocument, DoapProject[]>();
+			uniqueDocArtifactOf = Maps.newHashMap();
 			this.uniqueArtifactOfs.put(spdxDocument, uniqueDocArtifactOf);
 		}
 		Iterator<Entry<SpdxDocument, SpdxItem>> iter = this.documentItem.entrySet().iterator();
@@ -320,10 +317,9 @@ public class SpdxFileComparer extends SpdxItemComparer {
 				continue;
 			}
 			DoapProject[] compareArtifactOf = ((SpdxFile)entry.getValue()).getArtifactOf();
-			HashMap<SpdxDocument, DoapProject[]> uniqueCompareArtifactOf = 
-					this.uniqueArtifactOfs.get(entry.getKey());
+			Map<SpdxDocument, DoapProject[]> uniqueCompareArtifactOf = this.uniqueArtifactOfs.get(entry.getKey());
 			if (uniqueCompareArtifactOf == null) {
-				uniqueCompareArtifactOf = new HashMap<SpdxDocument, DoapProject[]>();
+				uniqueCompareArtifactOf = Maps.newHashMap();
 				this.uniqueArtifactOfs.put(entry.getKey(), uniqueCompareArtifactOf);
 			}
 			ArrayList<DoapProject> alDocUnique = new ArrayList<DoapProject>();
@@ -379,7 +375,8 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	 * @throws SpdxCompareException 
 	 * 
 	 */
-	protected void checkInProgress() throws SpdxCompareException {
+	@Override
+    protected void checkInProgress() throws SpdxCompareException {
 		super.checkInProgress();
 		if (inProgress) {
 			throw(new SpdxCompareException("File compare in progress - can not obtain compare results until compare has completed"));
@@ -422,7 +419,8 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	 * @return
 	 * @throws SpdxCompareException 
 	 */
-	public boolean isDifferenceFound() throws SpdxCompareException {
+	@Override
+    public boolean isDifferenceFound() throws SpdxCompareException {
 		checkInProgress();
 		checkCompareMade();
 		return differenceFound || super.isDifferenceFound();

--- a/src/org/spdx/compare/SpdxItemComparer.java
+++ b/src/org/spdx/compare/SpdxItemComparer.java
@@ -17,8 +17,9 @@
 package org.spdx.compare;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.spdx.rdfparser.license.AnyLicenseInfo;
@@ -26,6 +27,8 @@ import org.spdx.rdfparser.model.Annotation;
 import org.spdx.rdfparser.model.Relationship;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxItem;
+
+import com.google.common.collect.Maps;
 
 /**
  * Compares two SPDX items.  The <code>compare(itemA, itemB)</code> method will perform the comparison and
@@ -43,8 +46,8 @@ public class SpdxItemComparer {
 	/**
 	 * Map of unique extractedLicenseInfos between two documents
 	 */
-	HashMap<SpdxDocument, HashMap<SpdxDocument, AnyLicenseInfo[]>> uniqueLicenseInfosInFiles = 
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, AnyLicenseInfo[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, AnyLicenseInfo[]>> uniqueLicenseInfosInFiles = Maps.newHashMap();
+	
 	private boolean commentsEquals = true;
 	private boolean copyrightsEquals = true;
 	private boolean licenseCommmentsEquals = true;
@@ -52,26 +55,26 @@ public class SpdxItemComparer {
 	/**
 	 * Map of unique relationships between two documents
 	 */
-	HashMap<SpdxDocument, HashMap<SpdxDocument, Relationship[]>> uniqueRelationships =
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, Relationship[]>>();
+	Map<SpdxDocument, Map<SpdxDocument, Relationship[]>> uniqueRelationships = Maps.newHashMap();
+	
 	private boolean annotationsEquals = true;
 	/**
 	 * Map of unique annotations between two documents
 	 */
-	HashMap<SpdxDocument, HashMap<SpdxDocument, Annotation[]>> uniqueAnnotations =
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, Annotation[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, Annotation[]>> uniqueAnnotations = Maps.newHashMap();
+	
 	/**
 	 * Map of SPDX document to Items
 	 */
-	protected HashMap<SpdxDocument, SpdxItem> documentItem = 
-			new HashMap<SpdxDocument, SpdxItem>();
+	protected Map<SpdxDocument, SpdxItem> documentItem = Maps.newHashMap();
+	
 	/**
 	 * Mapping of all extracted license info ID's between all SPDX documents included in the comparer
 	 */
-	protected HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> extractedLicenseIdMap;
+	protected Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap;
 
 	
-	public SpdxItemComparer(HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> extractedLicenseIdMap) {
+	public SpdxItemComparer(Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap) {
 		this.extractedLicenseIdMap = extractedLicenseIdMap;
 	}
 	
@@ -99,7 +102,7 @@ public class SpdxItemComparer {
 		if (iter.hasNext()) {
 			Entry<SpdxDocument, SpdxItem> entry = iter.next();
 			SpdxItem itemB = entry.getValue();
-			HashMap<String, String> licenseXlationMap = this.extractedLicenseIdMap.get(spdxDocument).get(entry.getKey());
+			Map<String, String> licenseXlationMap = this.extractedLicenseIdMap.get(spdxDocument).get(entry.getKey());
 			if (!SpdxComparer.stringsEqual(spdxItem.getComment(), itemB.getComment())) {
 				this.commentsEquals = false;
 				this.differenceFound = true;
@@ -141,19 +144,17 @@ public class SpdxItemComparer {
 	 */
 	private void compareAnnotation(SpdxDocument spdxDocument,
 			Annotation[] annotations) {
-		HashMap<SpdxDocument, Annotation[]> uniqueDocAnnotations = 
-				this.uniqueAnnotations.get(spdxDocument);
+		Map<SpdxDocument, Annotation[]> uniqueDocAnnotations = this.uniqueAnnotations.get(spdxDocument);
 		if (uniqueDocAnnotations == null) {
-			uniqueDocAnnotations = new HashMap<SpdxDocument, Annotation[]>();
+			uniqueDocAnnotations = Maps.newHashMap();
 			this.uniqueAnnotations.put(spdxDocument, uniqueDocAnnotations);
 		}
 		Iterator<Entry<SpdxDocument, SpdxItem>> iter = this.documentItem.entrySet().iterator();
 		while (iter.hasNext()) {
 			Entry<SpdxDocument, SpdxItem> entry = iter.next();
-			HashMap<SpdxDocument, Annotation[]> compareDocAnnotations = 
-					this.uniqueAnnotations.get(entry.getKey());
+			Map<SpdxDocument, Annotation[]> compareDocAnnotations = this.uniqueAnnotations.get(entry.getKey());
 			if (compareDocAnnotations == null) {
-				compareDocAnnotations = new HashMap<SpdxDocument, Annotation[]>();
+				compareDocAnnotations = Maps.newHashMap();
 				this.uniqueAnnotations.put(entry.getKey(), compareDocAnnotations);
 			}
 			Annotation[] compareAnnotations = entry.getValue().getAnnotations();
@@ -181,19 +182,17 @@ public class SpdxItemComparer {
 	 */
 	private void compareRelationships(SpdxDocument spdxDocument,
 			Relationship[] relationships) {
-		HashMap<SpdxDocument, Relationship[]> uniqueDocRelationship = 
-				this.uniqueRelationships.get(spdxDocument);
+		Map<SpdxDocument, Relationship[]> uniqueDocRelationship = this.uniqueRelationships.get(spdxDocument);
 		if (uniqueDocRelationship == null) {
-			uniqueDocRelationship = new HashMap<SpdxDocument, Relationship[]>();
+			uniqueDocRelationship = Maps.newHashMap();
 			this.uniqueRelationships.put(spdxDocument, uniqueDocRelationship);
 		}
 		Iterator<Entry<SpdxDocument, SpdxItem>> iter = this.documentItem.entrySet().iterator();
 		while (iter.hasNext()) {
 			Entry<SpdxDocument, SpdxItem> entry = iter.next();
-			HashMap<SpdxDocument, Relationship[]> uniqueCompareRelationship = 
-					this.uniqueRelationships.get(entry.getKey());
+			Map<SpdxDocument, Relationship[]> uniqueCompareRelationship = this.uniqueRelationships.get(entry.getKey());
 			if (uniqueCompareRelationship == null) {
-				uniqueCompareRelationship = new HashMap<SpdxDocument, Relationship[]>();
+				uniqueCompareRelationship = Maps.newHashMap();
 				this.uniqueRelationships.put(entry.getKey(), uniqueCompareRelationship);
 			}
 			Relationship[] compareRelationships = entry.getValue().getRelationships();
@@ -222,25 +221,25 @@ public class SpdxItemComparer {
 	 */
 	private void compareLicenseInfosInFiles(SpdxDocument spdxDocument,
 			AnyLicenseInfo[] licenses) throws SpdxCompareException {
-		HashMap<SpdxDocument, AnyLicenseInfo[]> uniqueDocLicenses = 
+		Map<SpdxDocument, AnyLicenseInfo[]> uniqueDocLicenses = 
 				this.uniqueLicenseInfosInFiles.get(spdxDocument);
 		if (uniqueDocLicenses == null) {
-			uniqueDocLicenses = new HashMap<SpdxDocument, AnyLicenseInfo[]>();
+			uniqueDocLicenses = Maps.newHashMap();
 			this.uniqueLicenseInfosInFiles.put(spdxDocument, uniqueDocLicenses);
 		}
 		Iterator<Entry<SpdxDocument, SpdxItem>> iter = this.documentItem.entrySet().iterator();
 		while (iter.hasNext()) {
 			Entry<SpdxDocument, SpdxItem> entry = iter.next();
-			HashMap<SpdxDocument, AnyLicenseInfo[]> uniqueCompareLicenses = 
+			Map<SpdxDocument, AnyLicenseInfo[]> uniqueCompareLicenses = 
 					this.uniqueLicenseInfosInFiles.get(entry.getKey());
 			if (uniqueCompareLicenses == null) {
-				uniqueCompareLicenses = new HashMap<SpdxDocument, AnyLicenseInfo[]>();
+				uniqueCompareLicenses = Maps.newHashMap();
 				this.uniqueLicenseInfosInFiles.put(entry.getKey(), uniqueCompareLicenses);
 			}
 			AnyLicenseInfo[] compareLicenses = entry.getValue().getLicenseInfoFromFiles();
 			ArrayList<AnyLicenseInfo> uniqueInDoc = new ArrayList<AnyLicenseInfo>();
 			ArrayList<AnyLicenseInfo> uniqueInCompare = new ArrayList<AnyLicenseInfo>();
-			HashMap<String, String> licenseXlationMap = this.extractedLicenseIdMap.get(spdxDocument).get(entry.getKey());
+			Map<String, String> licenseXlationMap = this.extractedLicenseIdMap.get(spdxDocument).get(entry.getKey());
 			compareLicenseArrays(licenses, compareLicenses, uniqueInDoc, uniqueInCompare, licenseXlationMap);
 			if (uniqueInDoc.size() > 0 || uniqueInCompare.size() > 0) {
 				this.seenLicenseEquals = false;
@@ -265,9 +264,9 @@ public class SpdxItemComparer {
 	 */
 	private void compareLicenseArrays(AnyLicenseInfo[] licensesA,
 			AnyLicenseInfo[] licensesB,
-			ArrayList<AnyLicenseInfo> alUniqueA,
-			ArrayList<AnyLicenseInfo> alUniqueB,
-			HashMap<String, String> licenseXlationMap) throws SpdxCompareException {
+			List<AnyLicenseInfo> alUniqueA,
+			List<AnyLicenseInfo> alUniqueB,
+			Map<String, String> licenseXlationMap) throws SpdxCompareException {
 		// a bit brute force, but sorting licenses is a bit complex
 		// an N x M comparison of the licenses to determine which ones are unique
 		for (int i = 0; i < licensesA.length; i++) {
@@ -329,8 +328,7 @@ public class SpdxItemComparer {
 	public AnyLicenseInfo[] getUniqueSeenLicenses(SpdxDocument docA, SpdxDocument docB) throws SpdxCompareException {
 		checkInProgress();
 		checkCompareMade();
-		HashMap<SpdxDocument, AnyLicenseInfo[]> unique = 
-				this.uniqueLicenseInfosInFiles.get(docA);
+		Map<SpdxDocument, AnyLicenseInfo[]> unique =  this.uniqueLicenseInfosInFiles.get(docA);
 		if (unique == null) {
 			return new AnyLicenseInfo[0];
 		}
@@ -440,7 +438,7 @@ public class SpdxItemComparer {
 	public Relationship[] getUniqueRelationship(SpdxDocument docA, SpdxDocument docB) throws SpdxCompareException {
 		checkInProgress();
 		checkCompareMade();
-		HashMap<SpdxDocument, Relationship[]> unique = this.uniqueRelationships.get(docA);
+		Map<SpdxDocument, Relationship[]> unique = this.uniqueRelationships.get(docA);
 		if (unique == null) {
 			return new Relationship[0];
 		}
@@ -472,7 +470,7 @@ public class SpdxItemComparer {
 	public Annotation[] getUniqueAnnotations(SpdxDocument docA, SpdxDocument docB) throws SpdxCompareException {
 		checkInProgress();
 		checkCompareMade();
-		HashMap<SpdxDocument, Annotation[]> unique = this.uniqueAnnotations.get(docA);
+		Map<SpdxDocument, Annotation[]> unique = this.uniqueAnnotations.get(docA);
 		if (unique == null) {
 			return new Annotation[0];
 		}

--- a/src/org/spdx/compare/SpdxPackageComparer.java
+++ b/src/org/spdx/compare/SpdxPackageComparer.java
@@ -17,8 +17,8 @@
 package org.spdx.compare;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
@@ -27,6 +27,8 @@ import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxItem;
 import org.spdx.rdfparser.model.SpdxPackage;
+
+import com.google.common.collect.Maps;
 
 /**
  * Compares two SPDX package.  The <code>compare(pkgA, pkgB)</code> method will perform the comparison and
@@ -54,23 +56,22 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	/**
 	 * Map of documents to a map of documents with unique checksums
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, Checksum[]>> uniqueChecksums = 
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, Checksum[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, Checksum[]>> uniqueChecksums = Maps.newHashMap();
 
 	/**
 	 * Map of documents to a map of documents with unique files
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxFile[]>> uniqueFiles = 
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxFile[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, SpdxFile[]>> uniqueFiles = Maps.newHashMap();
+	
 	/**
 	 * Map of all file differences founds between any two spdx document packages
 	 */
-	private HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxFileDifference[]>> fileDifferences = 
-			new HashMap<SpdxDocument, HashMap<SpdxDocument, SpdxFileDifference[]>>();
+	private Map<SpdxDocument, Map<SpdxDocument, SpdxFileDifference[]>> fileDifferences = Maps.newHashMap();
+	
 	/**
 	 * @param extractedLicenseIdMap map of all extracted license IDs for any SPDX documents to be added to the comparer
 	 */
-	public SpdxPackageComparer(HashMap<SpdxDocument, HashMap<SpdxDocument, HashMap<String, String>>> extractedLicenseIdMap) {
+	public SpdxPackageComparer(Map<SpdxDocument, Map<SpdxDocument, Map<String, String>>> extractedLicenseIdMap) {
 		super(extractedLicenseIdMap);
 	}
 	
@@ -93,7 +94,7 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 		inProgress = true;
 		Iterator<Entry<SpdxDocument, SpdxItem>> iter = this.documentItem.entrySet().iterator();
 		SpdxPackage pkg2 = null;
-		HashMap<String, String> licenseXlationMap = null;
+		Map<String, String> licenseXlationMap = null;
 		while (iter.hasNext() && pkg2 == null) {
 			Entry<SpdxDocument, SpdxItem> entry = iter.next();
 			if (entry.getValue() instanceof SpdxPackage) {
@@ -179,14 +180,14 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	private void compareNewPackageFiles(SpdxDocument spdxDocument,
 			SpdxFile[] files) throws SpdxCompareException, InvalidSPDXAnalysisException {
 		Arrays.sort(files);
-		HashMap<SpdxDocument, SpdxFile[]> docUniqueFiles = this.uniqueFiles.get(spdxDocument);
+		Map<SpdxDocument, SpdxFile[]> docUniqueFiles = this.uniqueFiles.get(spdxDocument);
 		if (docUniqueFiles == null) {
-			docUniqueFiles = new HashMap<SpdxDocument, SpdxFile[]>();
+			docUniqueFiles = Maps.newHashMap();
 			this.uniqueFiles.put(spdxDocument, docUniqueFiles);
 		}
-		HashMap<SpdxDocument, SpdxFileDifference[]> docDifferentFiles = this.fileDifferences.get(spdxDocument);
+		Map<SpdxDocument, SpdxFileDifference[]> docDifferentFiles = this.fileDifferences.get(spdxDocument);
 		if (docDifferentFiles == null) {
-			docDifferentFiles = new HashMap<SpdxDocument, SpdxFileDifference[]>();
+			docDifferentFiles = Maps.newHashMap();
 			this.fileDifferences.put(spdxDocument, docDifferentFiles);
 		}
 		Iterator<Entry<SpdxDocument, SpdxItem>> iter = this.documentItem.entrySet().iterator();
@@ -202,10 +203,9 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 					this.differenceFound = true;
 				}
 				docDifferentFiles.put(entry.getKey(), fileDifferences);
-				HashMap<SpdxDocument, SpdxFileDifference[]> compareDifferentFiles = 
-						this.fileDifferences.get(entry.getKey());
+				Map<SpdxDocument, SpdxFileDifference[]> compareDifferentFiles = this.fileDifferences.get(entry.getKey());
 				if (compareDifferentFiles == null) {
-					compareDifferentFiles = new HashMap<SpdxDocument, SpdxFileDifference[]>();
+					compareDifferentFiles = Maps.newHashMap();
 					this.fileDifferences.put(entry.getKey(), compareDifferentFiles);
 				}
 				compareDifferentFiles.put(spdxDocument, fileDifferences);
@@ -215,10 +215,9 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 					this.differenceFound = true;
 				}
 				docUniqueFiles.put(entry.getKey(), uniqueFiles);
-				HashMap<SpdxDocument, SpdxFile[]> compareUniqueFiles = 
-						this.uniqueFiles.get(entry.getKey());
+				Map<SpdxDocument, SpdxFile[]> compareUniqueFiles = this.uniqueFiles.get(entry.getKey());
 				if (compareUniqueFiles == null) {
-					compareUniqueFiles = new HashMap<SpdxDocument, SpdxFile[]>();
+					compareUniqueFiles = Maps.newHashMap();
 					this.uniqueFiles.put(entry.getKey(), compareUniqueFiles);
 				}
 				uniqueFiles = SpdxComparer.findUniqueFiles(compareFiles, files);
@@ -241,8 +240,7 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	private void compareNewPackageChecksums(SpdxDocument spdxDocument,
 			Checksum[] checksums) throws SpdxCompareException {
 		try {
-			HashMap<SpdxDocument, Checksum[]> docUniqueChecksums = 
-					new HashMap<SpdxDocument, Checksum[]>();
+			Map<SpdxDocument, Checksum[]> docUniqueChecksums = Maps.newHashMap();
 			this.uniqueChecksums.put(spdxDocument, docUniqueChecksums);
 			Iterator<Entry<SpdxDocument,SpdxItem>> iter = this.documentItem.entrySet().iterator();
 			while (iter.hasNext()) {
@@ -255,9 +253,9 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 						this.differenceFound = true;
 					}
 					docUniqueChecksums.put(entry.getKey(), uniqueChecksums);
-					HashMap<SpdxDocument, Checksum[]> compareUniqueChecksums = this.uniqueChecksums.get(entry.getKey());
+					Map<SpdxDocument, Checksum[]> compareUniqueChecksums = this.uniqueChecksums.get(entry.getKey());
 					if (compareUniqueChecksums == null) {
-						compareUniqueChecksums = new HashMap<SpdxDocument, Checksum[]>();
+						compareUniqueChecksums = Maps.newHashMap();
 						this.uniqueChecksums.put(entry.getKey(), compareUniqueChecksums);
 					}
 					uniqueChecksums = SpdxComparer.findUniqueChecksums(compareChecksums, checksums);
@@ -276,7 +274,8 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	/**
 	 * @return the inProgress
 	 */
-	public boolean isInProgress() {
+	@Override
+    public boolean isInProgress() {
 		return inProgress;
 	}
 
@@ -284,7 +283,8 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	 * @return the differenceFound
 	 * @throws SpdxCompareException 
 	 */
-	public boolean isDifferenceFound() throws SpdxCompareException {
+	@Override
+    public boolean isDifferenceFound() throws SpdxCompareException {
 		checkInProgress();
 		return differenceFound || super.isDifferenceFound();
 	} 
@@ -294,7 +294,8 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	 * @throws SpdxCompareException 
 	 * 
 	 */
-	protected void checkInProgress() throws SpdxCompareException {
+	@Override
+    protected void checkInProgress() throws SpdxCompareException {
 		if (inProgress) {
 			throw(new SpdxCompareException("File compare in progress - can not obtain compare results until compare has completed"));
 		}
@@ -417,8 +418,7 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	 */
 	public Checksum[] getUniqueChecksums(SpdxDocument docA, SpdxDocument docB) throws SpdxCompareException {
 		checkInProgress();
-		HashMap<SpdxDocument, Checksum[]> uniqueMap = 
-				this.uniqueChecksums.get(docA);
+		Map<SpdxDocument, Checksum[]> uniqueMap = this.uniqueChecksums.get(docA);
 		if (uniqueMap == null) {
 			return new Checksum[0];
 		}
@@ -446,7 +446,7 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	public SpdxFileDifference[] getFileDifferences(SpdxDocument docA, 
 			SpdxDocument docB) throws SpdxCompareException {
 		checkInProgress();
-		HashMap<SpdxDocument, SpdxFileDifference[]> uniqueMap = this.fileDifferences.get(docA);
+		Map<SpdxDocument, SpdxFileDifference[]> uniqueMap = this.fileDifferences.get(docA);
 		if (uniqueMap == null) {
 			return new SpdxFileDifference[0];
 		}
@@ -466,7 +466,7 @@ public class SpdxPackageComparer extends SpdxItemComparer {
 	 */
 	public SpdxFile[] getUniqueFiles(SpdxDocument docA, SpdxDocument docB) throws SpdxCompareException {
 		checkInProgress();
-		HashMap<SpdxDocument, SpdxFile[]> uniqueMap = this.uniqueFiles.get(docA);
+		Map<SpdxDocument, SpdxFile[]> uniqueMap = this.uniqueFiles.get(docA);
 		if (uniqueMap == null) {
 			return new SpdxFile[0];
 		}

--- a/src/org/spdx/html/ElementContext.java
+++ b/src/org/spdx/html/ElementContext.java
@@ -16,7 +16,7 @@
 */
 package org.spdx.html;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.model.SpdxElement;
@@ -35,8 +35,7 @@ public class ElementContext {
 	public ElementContext(InvalidSPDXAnalysisException e) {
 		this.error = e.getMessage();
 	}
-	public ElementContext(SpdxElement element, 
-			HashMap<String, String> spdxIdToUrl) {
+	public ElementContext(SpdxElement element, Map<String, String> spdxIdToUrl) {
 		if (element == null) {
 			return;
 		}

--- a/src/org/spdx/html/ExceptionHtml.java
+++ b/src/org/spdx/html/ExceptionHtml.java
@@ -21,7 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
 import org.spdx.rdfparser.license.LicenseException;
@@ -29,6 +29,7 @@ import org.spdx.rdfparser.license.LicenseException;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
+import com.google.common.collect.Maps;
 
 
 /**
@@ -42,7 +43,8 @@ public class ExceptionHtml {
 	static final String TEMPLATE_ROOT_PATH = "resources" + File.separator + "htmlTemplate";
 	static final String HTML_TEMPLATE = "ExceptionHTMLTemplate.html";
 	
-	HashMap<String, Object> mustacheMap = new HashMap<String, Object>();
+	Map<String, Object> mustacheMap = Maps.newHashMap();
+	
 	/**
 	 * @param exception
 	 */

--- a/src/org/spdx/html/ExceptionHtmlToc.java
+++ b/src/org/spdx/html/ExceptionHtmlToc.java
@@ -21,14 +21,15 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.spdx.rdfparser.license.LicenseException;
 
-import com.github.mustachejava.Mustache;
 import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
+import com.google.common.collect.Maps;
 
 /**
  * Generates the HTML Table of Contents for License Exceptions
@@ -140,7 +141,7 @@ public class ExceptionHtmlToc {
 	 */
 	public void writeToFile(File exceptionTocFile, String version) throws MustacheException, IOException {
 
-		HashMap<String, Object> mustacheMap = new HashMap<String, Object>();
+		Map<String, Object> mustacheMap = Maps.newHashMap();
 		mustacheMap.put("version", StringEscapeUtils.escapeHtml4(version));
 		mustacheMap.put("listedExceptions", exceptions);
 		FileOutputStream stream = null;

--- a/src/org/spdx/html/ExtractedLicensingInfoContext.java
+++ b/src/org/spdx/html/ExtractedLicensingInfoContext.java
@@ -17,8 +17,8 @@
 package org.spdx.html;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
@@ -44,8 +44,7 @@ public class ExtractedLicensingInfoContext {
 	 * @param spdxNonStandardLicense
 	 * @param spdxIdToUrl 
 	 */
-	public ExtractedLicensingInfoContext(
-			ExtractedLicenseInfo spdxNonStandardLicense, HashMap<String, String> spdxIdToUrl) {
+	public ExtractedLicensingInfoContext(ExtractedLicenseInfo spdxNonStandardLicense, Map<String, String> spdxIdToUrl) {
 		this.license = spdxNonStandardLicense;
 		if (this.license != null) {
 			this.licenseLink = spdxIdToUrl.get(this.license.getLicenseId());

--- a/src/org/spdx/html/LicenseHTMLFile.java
+++ b/src/org/spdx/html/LicenseHTMLFile.java
@@ -21,7 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,9 +29,10 @@ import org.spdx.licenseTemplate.LicenseTemplateRuleException;
 import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
 import org.spdx.rdfparser.license.SpdxListedLicense;
 
-import com.github.mustachejava.Mustache;
 import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
+import com.google.common.collect.Maps;
 
 /**
  * This class contains a formatted HTML file for a given license.  Specific
@@ -155,7 +156,7 @@ public class LicenseHTMLFile {
 			stream = new FileOutputStream(htmlFile);
 			writer = new OutputStreamWriter(stream, "UTF-8");
 			DefaultMustacheFactory builder = new DefaultMustacheFactory(templateDirName);
-	        HashMap<String, Object> mustacheMap = buildMustachMap();
+	        Map<String, Object> mustacheMap = buildMustachMap();
 	        Mustache mustache = builder.compile(TEMPLATE_FILE_NAME);
 	        mustache.execute(writer, mustacheMap);
 		} finally {
@@ -171,8 +172,8 @@ public class LicenseHTMLFile {
 	 * @return
 	 * @throws LicenseTemplateRuleException 
 	 */
-	private HashMap<String, Object> buildMustachMap() throws LicenseTemplateRuleException {
-			HashMap<String, Object> retval = new HashMap<String, Object>();
+	private Map<String, Object> buildMustachMap() throws LicenseTemplateRuleException {
+			Map<String, Object> retval = Maps.newHashMap();
 			if (license != null) {
 				retval.put("licenseId", license.getLicenseId());
 				String licenseTextHtml = null;

--- a/src/org/spdx/html/LicenseTOCHTMLFile.java
+++ b/src/org/spdx/html/LicenseTOCHTMLFile.java
@@ -21,14 +21,15 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.spdx.rdfparser.license.SpdxListedLicense;
 import org.spdx.spdxspreadsheet.SPDXLicenseSpreadsheet.DeprecatedLicenseInfo;
 
-import com.github.mustachejava.Mustache;
 import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
+import com.google.common.collect.Maps;
 
 /**
  * This class holds a formatted HTML file for a license table of contents
@@ -273,7 +274,7 @@ public class LicenseTOCHTMLFile {
 			stream = new FileOutputStream(htmlFile);
 			writer = new OutputStreamWriter(stream, "UTF-8");
 			DefaultMustacheFactory builder = new DefaultMustacheFactory(templateDirName);
-	        HashMap<String, Object> mustacheMap = buildMustachMap();
+	        Map<String, Object> mustacheMap = buildMustachMap();
 	        Mustache mustache = builder.compile(HTML_TEMPLATE);
 	        mustache.execute(writer, mustacheMap);
 		} finally {
@@ -289,8 +290,8 @@ public class LicenseTOCHTMLFile {
 	 * Build the a hash map to map the variables in the template to the values
 	 * @return
 	 */
-	private HashMap<String, Object> buildMustachMap() {
-		HashMap<String, Object> retval = new HashMap<String, Object>();
+	private Map<String, Object> buildMustachMap() {
+		Map<String, Object> retval = Maps.newHashMap();
 		retval.put("version", generateVersionString(version, releaseDate));
 		retval.put("listedLicenses", this.listedLicenses);
 		retval.put("deprecatedLicenses", this.deprecatedLicenses);

--- a/src/org/spdx/html/MustacheMap.java
+++ b/src/org/spdx/html/MustacheMap.java
@@ -19,8 +19,8 @@ package org.spdx.html;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SPDXReview;
@@ -35,6 +35,8 @@ import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxItem;
 import org.spdx.rdfparser.model.SpdxPackage;
 
+import com.google.common.collect.Maps;
+
 /**
  * Provides a hashmap which maps the Mustache template strings to SPDX Document
  * methods and strings.  The constants are used in the SpdxHTMLTemplate.html file
@@ -47,9 +49,9 @@ import org.spdx.rdfparser.model.SpdxPackage;
  */
 public class MustacheMap {
 
-	public static HashMap<String, Object> buildDocMustachMap(SpdxDocument doc,
-			HashMap<String, String> spdxIdToUrl) throws InvalidSPDXAnalysisException {
-		HashMap<String, Object>  retval = new HashMap<String, Object>();
+	public static Map<String, Object> buildDocMustachMap(SpdxDocument doc,
+			Map<String, String> spdxIdToUrl) throws InvalidSPDXAnalysisException {
+		Map<String, Object>  retval = Maps.newHashMap();
 		// Document level information
 		retval.put("documentName", doc.getName());
 		retval.put("documentNamespace", doc.getDocumentNamespace());
@@ -108,7 +110,7 @@ public class MustacheMap {
 	 * @return
 	 */
 	private static List<RelationshipContext> getRelationshipContexts(
-			Relationship[] relationships, HashMap<String, String> spdxIdToUrl) {
+			Relationship[] relationships, Map<String, String> spdxIdToUrl) {
 		Arrays.sort(relationships);
 		ArrayList<RelationshipContext> retval = new ArrayList<RelationshipContext>();
 		if (relationships == null) {
@@ -127,10 +129,9 @@ public class MustacheMap {
 	 * @return
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	public static HashMap<String, Object> buildDocFileMustacheMap(
-			SpdxDocument doc, SpdxFile[] files,
-			HashMap<String, String> spdxIdToUrl) throws InvalidSPDXAnalysisException {
-		HashMap<String, Object> retval = new HashMap<String, Object>();
+	public static Map<String, Object> buildDocFileMustacheMap(SpdxDocument doc, SpdxFile[] files,
+			Map<String, String> spdxIdToUrl) throws InvalidSPDXAnalysisException {
+		Map<String, Object> retval = Maps.newHashMap();
 		retval.put("about", "SPDX Document "+doc.getName());
 		SpdxItem[] describedItems = doc.getDocumentDescribes();
 		Arrays.sort(describedItems, new Comparator<SpdxItem>() {
@@ -159,8 +160,7 @@ public class MustacheMap {
 		return retval;
 	}
 	
-	private static ArrayList<ExtractedLicensingInfoContext> getExtractedLicensingInfo(SpdxDocument doc,
-			HashMap<String, String> spdxIdToUrl) {
+	private static ArrayList<ExtractedLicensingInfoContext> getExtractedLicensingInfo(SpdxDocument doc, Map<String, String> spdxIdToUrl) {
 		ArrayList<ExtractedLicensingInfoContext> retval = new ArrayList<ExtractedLicensingInfoContext>();
 		try {
 			ExtractedLicenseInfo[] extractedLicenseInfos = doc.getExtractedLicenseInfos();
@@ -235,9 +235,8 @@ public class MustacheMap {
 	 * @param spdxIdToUrl
 	 * @return
 	 */
-	public static HashMap<String, Object> buildExtractedLicMustachMap(
-			SpdxDocument doc, HashMap<String, String> spdxIdToUrl) {
-		HashMap<String, Object> retval = new HashMap<String, Object>();
+	public static Map<String, Object> buildExtractedLicMustachMap(SpdxDocument doc, Map<String, String> spdxIdToUrl) {
+		Map<String, Object> retval = Maps.newHashMap();
 		retval.put("hasExtractedLicensingInfo", getExtractedLicensingInfo(doc, spdxIdToUrl));
 		return retval;
 	}
@@ -248,9 +247,9 @@ public class MustacheMap {
 	 * @return
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	public static HashMap<String, Object> buildPkgFileMap(SpdxPackage pkg,
-			HashMap<String, String> spdxIdToUrl) throws InvalidSPDXAnalysisException {
-		HashMap<String, Object> retval = new HashMap<String, Object>();
+	public static Map<String, Object> buildPkgFileMap(SpdxPackage pkg,
+			Map<String, String> spdxIdToUrl) throws InvalidSPDXAnalysisException {
+		Map<String, Object> retval = Maps.newHashMap();
 		retval.put("about", "SPDX Package "+pkg.getName());
 		SpdxFile[] files = pkg.getFiles();
 		Arrays.sort(files, new Comparator<SpdxFile>() {
@@ -272,7 +271,7 @@ public class MustacheMap {
 		ArrayList<FileContext> alFiles = new ArrayList<FileContext>();
 		for (int i = 0; i < files.length; i++) {
 			if (files[i] instanceof SpdxFile) {
-				alFiles.add(new FileContext((SpdxFile)files[i]));
+				alFiles.add(new FileContext(files[i]));
 			}
 		}
 		retval.put("hasFile", alFiles);

--- a/src/org/spdx/html/PackageContext.java
+++ b/src/org/spdx/html/PackageContext.java
@@ -19,15 +19,15 @@ package org.spdx.html;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.model.Checksum;
-import org.spdx.rdfparser.model.SpdxPackage;
-import org.spdx.rdfparser.license.AnyLicenseInfo;
-import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.SpdxPackageVerificationCode;
+import org.spdx.rdfparser.license.AnyLicenseInfo;
+import org.spdx.rdfparser.model.Checksum;
+import org.spdx.rdfparser.model.SpdxFile;
+import org.spdx.rdfparser.model.SpdxPackage;
 
 /**
  * Context for SPDX Package
@@ -37,13 +37,13 @@ import org.spdx.rdfparser.SpdxPackageVerificationCode;
 public class PackageContext {
 	
 	private SpdxPackage pkg = null;
-	private HashMap<String, String> spdxIdToUrl;
+	private Map<String, String> spdxIdToUrl;
 
 	/**
 	 * @param doc
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	public PackageContext(SpdxPackage pkg, HashMap<String, String> spdxIdToUrl) throws InvalidSPDXAnalysisException {
+	public PackageContext(SpdxPackage pkg, Map<String, String> spdxIdToUrl) throws InvalidSPDXAnalysisException {
 		this.pkg = pkg;
 		this.spdxIdToUrl = spdxIdToUrl;
 	}

--- a/src/org/spdx/html/RelationshipContext.java
+++ b/src/org/spdx/html/RelationshipContext.java
@@ -16,7 +16,7 @@
 */
 package org.spdx.html;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.spdx.rdfparser.model.Relationship;
 import org.spdx.rdfparser.model.SpdxElement;
@@ -37,7 +37,7 @@ public class RelationshipContext {
 		
 	}
 	
-	public RelationshipContext(Relationship relationship, HashMap<String, String> idToUrlMap) {
+	public RelationshipContext(Relationship relationship, Map<String, String> idToUrlMap) {
 		if (relationship == null) {
 			return;
 		}

--- a/src/org/spdx/merge/SpdxLicenseMapper.java
+++ b/src/org/spdx/merge/SpdxLicenseMapper.java
@@ -17,7 +17,7 @@
 package org.spdx.merge;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
@@ -27,6 +27,8 @@ import org.spdx.rdfparser.license.DisjunctiveLicenseSet;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxFile;
+
+import com.google.common.collect.Maps;
 
 /**
  * Application to build HashMaps to help SPDX documents merging. Currently, it helps mapping any SPDX licenses.
@@ -39,8 +41,7 @@ import org.spdx.rdfparser.model.SpdxFile;
  */
 public class SpdxLicenseMapper {
 
-	private HashMap<SpdxDocument, HashMap<AnyLicenseInfo, AnyLicenseInfo>> nonStdLicIdMap = 
-			new HashMap<SpdxDocument, HashMap< AnyLicenseInfo, AnyLicenseInfo>>();
+	private Map<SpdxDocument, Map<AnyLicenseInfo, AnyLicenseInfo>> nonStdLicIdMap = Maps.newHashMap();
 	
 	/**
 	 * 
@@ -60,7 +61,7 @@ public class SpdxLicenseMapper {
 	 */
 	public ExtractedLicenseInfo mappingNewNonStdLic(SpdxDocument outputDoc, SpdxDocument subDoc, ExtractedLicenseInfo subNonStdLicInfo){
 		
-		HashMap<AnyLicenseInfo,AnyLicenseInfo> interMap = new HashMap<AnyLicenseInfo,AnyLicenseInfo>();
+		Map<AnyLicenseInfo,AnyLicenseInfo> interMap = Maps.newHashMap();
 		if(docInNonStdLicIdMap(subDoc)){
 			interMap = nonStdLicIdMap.get(subDoc);
 		}    
@@ -82,11 +83,11 @@ public class SpdxLicenseMapper {
 	 * @param outputDocLicense
 	 */
 	public void mappingExistingNonStdLic(SpdxDocument output, ExtractedLicenseInfo outputDocLicense, SpdxDocument subDocs, ExtractedLicenseInfo subLicense) {
-		HashMap<AnyLicenseInfo,AnyLicenseInfo> interMap;
+		Map<AnyLicenseInfo,AnyLicenseInfo> interMap;
 		if(docInNonStdLicIdMap(subDocs)){
 			interMap = nonStdLicIdMap.get(subDocs);
 		} else {
-			interMap = new HashMap<AnyLicenseInfo,AnyLicenseInfo>();
+			interMap = Maps.newHashMap();
 		}
 		interMap.put(outputDocLicense, subLicense);
 		nonStdLicIdMap.put(subDocs, interMap);
@@ -102,7 +103,7 @@ public class SpdxLicenseMapper {
 	 */
 	public SpdxFile replaceNonStdLicInFile(SpdxDocument spdxDoc, SpdxFile subFileInfo) throws InvalidSPDXAnalysisException{
 			AnyLicenseInfo[] subLicInfoInFile = subFileInfo.getLicenseInfoFromFiles();
-			HashMap<AnyLicenseInfo, AnyLicenseInfo> idMap = foundInterMap(spdxDoc);
+			Map<AnyLicenseInfo, AnyLicenseInfo> idMap = foundInterMap(spdxDoc);
 			Set <AnyLicenseInfo> keys = idMap.keySet();
 			AnyLicenseInfo[] orgNonStdLics = keys.toArray(new AnyLicenseInfo[idMap.keySet().size()]);
 			ArrayList <AnyLicenseInfo> retval = new ArrayList<AnyLicenseInfo>();
@@ -138,7 +139,7 @@ public class SpdxLicenseMapper {
 	 * @return
 	 */
 	public AnyLicenseInfo mapNonStdLicInMap(SpdxDocument spdxDoc, AnyLicenseInfo license){
-		HashMap<AnyLicenseInfo, AnyLicenseInfo> idMap = foundInterMap(spdxDoc);
+		Map<AnyLicenseInfo, AnyLicenseInfo> idMap = foundInterMap(spdxDoc);
 		ExtractedLicenseInfo[] orgNonStdLics = idMap.keySet().toArray(new ExtractedLicenseInfo[idMap.keySet().size()]);
 		for(int i = 0; i < orgNonStdLics.length; i++ ){
 			boolean foundLic = false;
@@ -178,7 +179,7 @@ public class SpdxLicenseMapper {
 			}
 			return new DisjunctiveLicenseSet(mappedMembers);
 		}else if(license instanceof ExtractedLicenseInfo){
-			return license = mapNonStdLicInMap(spdxDoc,(ExtractedLicenseInfo)license);
+			return license = mapNonStdLicInMap(spdxDoc,license);
 		}
 		return license;	
 	}
@@ -200,14 +201,9 @@ public class SpdxLicenseMapper {
 	 * @param spdxDoc
 	 * @return idMap
 	 */
-	public HashMap<AnyLicenseInfo, AnyLicenseInfo> foundInterMap(SpdxDocument spdxDoc){
+	public Map<AnyLicenseInfo, AnyLicenseInfo> foundInterMap(SpdxDocument spdxDoc){
+		return this.nonStdLicIdMap.get(spdxDoc);
 
-		HashMap<AnyLicenseInfo, AnyLicenseInfo> idMap = 
-				new HashMap<AnyLicenseInfo, AnyLicenseInfo>();
-		
-		idMap = this.nonStdLicIdMap.get(spdxDoc);
-		return idMap;
-		
 	}
 	
 	/**

--- a/src/org/spdx/rdfparser/SPDXChecksum.java
+++ b/src/org/spdx/rdfparser/SPDXChecksum.java
@@ -17,8 +17,9 @@
 package org.spdx.rdfparser;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -34,8 +35,8 @@ import com.hp.hpl.jena.util.iterator.ExtendedIterator;
 public class SPDXChecksum {
 
 	// Supported algorithms
-	public static final HashMap<String, String> ALGORITHM_TO_URI = new HashMap<String, String>();
-	public static final HashMap<String, String> URI_TO_ALGORITHM = new HashMap<String, String>();
+	public static final Map<String, String> ALGORITHM_TO_URI = Maps.newHashMap();
+	public static final Map<String, String> URI_TO_ALGORITHM = Maps.newHashMap();
 	static {
 		ALGORITHM_TO_URI.put(SpdxRdfConstants.ALGORITHM_SHA1, 
 				SpdxRdfConstants.SPDX_NAMESPACE+SpdxRdfConstants.PROP_CHECKSUM_ALGORITHM_SHA1);
@@ -280,7 +281,8 @@ public class SPDXChecksum {
 	/* (non-Javadoc)
 	 * @see java.lang.Object#clone()
 	 */
-	public SPDXChecksum clone() {
+	@Override
+    public SPDXChecksum clone() {
 		return new SPDXChecksum(this.algorithm, this.value);
 	}
 }

--- a/src/org/spdx/rdfparser/SPDXFile.java
+++ b/src/org/spdx/rdfparser/SPDXFile.java
@@ -17,13 +17,14 @@
 package org.spdx.rdfparser;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.DuplicateExtractedLicenseIdException;
 import org.spdx.rdfparser.license.LicenseInfoFactory;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -55,8 +56,8 @@ public class SPDXFile implements Comparable<SPDXFile>, Cloneable {
 	private String[] contributors;
 	private String noticeText;
 	
-	public static HashMap<String, String> FILE_TYPE_TO_RESOURCE = new HashMap<String, String>();
-	public static HashMap<String, String> RESOURCE_TO_FILE_TYPE = new HashMap<String, String>();
+	public static Map<String, String> FILE_TYPE_TO_RESOURCE = Maps.newHashMap();
+	public static Map<String, String> RESOURCE_TO_FILE_TYPE = Maps.newHashMap();
 
 	static {
 		FILE_TYPE_TO_RESOURCE.put(SpdxRdfConstants.FILE_TYPE_SOURCE, 
@@ -1194,6 +1195,7 @@ public class SPDXFile implements Comparable<SPDXFile>, Cloneable {
      * @see java.lang.Object#clone()
      * Creates a deep copy including clones of the files and artifactOfs referenced in the fileDependencies
      */
+    @Override
     public SPDXFile clone() {
     	SPDXFile[] cloneFileDependencies;
     	if (this.fileDependencies == null) {

--- a/src/org/spdx/rdfparser/SpdxDocumentContainer.java
+++ b/src/org/spdx/rdfparser/SpdxDocumentContainer.java
@@ -17,9 +17,9 @@
 package org.spdx.rdfparser;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 import org.spdx.rdfparser.license.AnyLicenseInfo;
@@ -36,6 +36,7 @@ import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxPackage;
 import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -77,19 +78,16 @@ public class SpdxDocumentContainer implements IModelContainer, SpdxRdfConstants 
 	/**
 	 * Map of license ID to extracted license info
 	 */
-	HashMap<String, ExtractedLicenseInfo> licenseIdToExtractedLicense = 
-			new HashMap<String, ExtractedLicenseInfo>();
+	Map<String, ExtractedLicenseInfo> licenseIdToExtractedLicense = Maps.newHashMap();
 	
 	/**
 	 * Map of external document ID's to external document references
 	 */
-	HashMap<String, ExternalDocumentRef> externalDocIdToRef = 
-			new HashMap<String, ExternalDocumentRef>();
+	Map<String, ExternalDocumentRef> externalDocIdToRef = Maps.newHashMap();
 	/**
 	 * Map of external document namespaces to external document references
 	 */
-	HashMap<String, ExternalDocumentRef> externalDocNamespaceToRef = 
-			new HashMap<String, ExternalDocumentRef>();
+	Map<String, ExternalDocumentRef> externalDocNamespaceToRef = Maps.newHashMap();
 	
 	static {
 		SUPPORTED_SPDX_VERSIONS.add(CURRENT_SPDX_VERSION);
@@ -381,7 +379,8 @@ public class SpdxDocumentContainer implements IModelContainer, SpdxRdfConstants 
 	/**
 	 * @return return the next available SPDX element reference.
 	 */
-	public String getNextSpdxElementRef() {
+	@Override
+    public String getNextSpdxElementRef() {
 		int nextSpdxElementNum = this.getAndIncrementNextElementRef();
 		String retval = formSpdxElementRef(nextSpdxElementNum);
 		while (this.spdxElementRefExists(retval)) {

--- a/src/org/spdx/rdfparser/VerificationCodeGenerator.java
+++ b/src/org/spdx/rdfparser/VerificationCodeGenerator.java
@@ -24,6 +24,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.TreeSet;
 
 import org.spdx.rdfparser.model.SpdxFile;
@@ -136,7 +137,7 @@ public class VerificationCodeGenerator {
 		return generatePackageVerificationCode(fileChecksums, skippedFileNames);
 	}
 	
-	protected SpdxPackageVerificationCode generatePackageVerificationCode(ArrayList<String> fileChecksums,
+	protected SpdxPackageVerificationCode generatePackageVerificationCode(List<String> fileChecksums,
 			String[] skippedFilePaths) throws NoSuchAlgorithmException {
 		Collections.sort(fileChecksums);
 		MessageDigest verificationCodeDigest = MessageDigest.getInstance("SHA-1");

--- a/src/org/spdx/rdfparser/license/LicenseExpressionParser.java
+++ b/src/org/spdx/rdfparser/license/LicenseExpressionParser.java
@@ -18,12 +18,14 @@ package org.spdx.rdfparser.license;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Stack;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxDocumentContainer;
 import org.spdx.rdfparser.SpdxRdfConstants;
+
+import com.google.common.collect.Maps;
 
 /**
  * A parser for the SPDX License EXpressions as documented in the SPDX appendix.
@@ -40,7 +42,8 @@ public class LicenseExpressionParser {
 	};
 	static final String LEFT_PAREN = "(";
 	static final String RIGHT_PAREN = ")";
-	static final HashMap<String, Operator> OPERATOR_MAP = new HashMap<String,Operator>();
+	static final Map<String, Operator> OPERATOR_MAP = Maps.newHashMap();
+	
 	static {
 		OPERATOR_MAP.put("+", Operator.OR_LATER);
 		OPERATOR_MAP.put("AND", Operator.AND);

--- a/src/org/spdx/rdfparser/license/ListedLicenses.java
+++ b/src/org/spdx/rdfparser/license/ListedLicenses.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -31,6 +31,7 @@ import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -60,8 +61,8 @@ public class ListedLicenses implements IModelContainer {
 	
 	HashSet<String> listdLicenseIds = null;
 	
-	HashMap<String, SpdxListedLicense> listedLicenseCache = null;
-	HashMap<Node, SpdxListedLicense> listedLicenseNodeCache = new HashMap<Node, SpdxListedLicense>();
+	Map<String, SpdxListedLicense> listedLicenseCache = null;
+	Map<Node, SpdxListedLicense> listedLicenseNodeCache = Maps.newHashMap();
 	
 
     
@@ -382,7 +383,7 @@ public class ListedLicenses implements IModelContainer {
     private void loadListedLicenseIDs() {
         listedLicenseModificationLock.writeLock().lock();
         try {
-            listedLicenseCache = new HashMap<String, SpdxListedLicense>(); // clear the cache
+            listedLicenseCache = Maps.newHashMap(); // clear the cache
             listdLicenseIds = new HashSet<String>(); //Clear the listed license IDs to avoid stale licenses.
             //TODO: Can the keys of listedLicenseCache be used instead of this set?
             Model stdLicenseModel = getListedLicenseModel();

--- a/src/org/spdx/rdfparser/model/Annotation.java
+++ b/src/org/spdx/rdfparser/model/Annotation.java
@@ -17,7 +17,7 @@
 package org.spdx.rdfparser.model;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.IModelContainer;
@@ -26,6 +26,7 @@ import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.SpdxVerificationHelper;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -41,10 +42,8 @@ public class Annotation extends RdfModelObject implements Comparable<Annotation>
 
 	public enum AnnotationType {annotationType_other, annotationType_review};
 	
-	public static final HashMap<AnnotationType, String> ANNOTATION_TYPE_TO_TAG = 
-			new HashMap<AnnotationType, String>();
-	public static final HashMap<String, AnnotationType> TAG_TO_ANNOTATION_TYPE = 
-			new HashMap<String, AnnotationType>();
+	public static final Map<AnnotationType, String> ANNOTATION_TYPE_TO_TAG = Maps.newHashMap();
+	public static final Map<String, AnnotationType> TAG_TO_ANNOTATION_TYPE = Maps.newHashMap();
 	static {
 		ANNOTATION_TYPE_TO_TAG.put(AnnotationType.annotationType_other, "OTHER");
 		TAG_TO_ANNOTATION_TYPE.put("OTHER", AnnotationType.annotationType_other);

--- a/src/org/spdx/rdfparser/model/RdfModelObject.java
+++ b/src/org/spdx/rdfparser/model/RdfModelObject.java
@@ -17,7 +17,7 @@
 package org.spdx.rdfparser.model;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
@@ -28,6 +28,7 @@ import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.LicenseInfoFactory;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -79,8 +80,8 @@ public abstract class RdfModelObject implements IRdfModel, Cloneable {
 	// the following hashmaps translate between pre-defined 
 	// property values and their URI's used to uniquely identify them
 	// in the RDF model
-	static final HashMap<String, String> PRE_DEFINED_VALUE_URI = new HashMap<String, String>();
-	static final HashMap<String, String> PRE_DEFINED_URI_VALUE = new HashMap<String, String>();
+	static final Map<String, String> PRE_DEFINED_VALUE_URI = Maps.newHashMap();
+	static final Map<String, String> PRE_DEFINED_URI_VALUE = Maps.newHashMap();
 	
 	static {
 		PRE_DEFINED_VALUE_URI.put(SpdxRdfConstants.NOASSERTION_VALUE, SpdxRdfConstants.URI_VALUE_NOASSERTION);

--- a/src/org/spdx/rdfparser/model/Relationship.java
+++ b/src/org/spdx/rdfparser/model/Relationship.java
@@ -17,7 +17,7 @@
 package org.spdx.rdfparser.model;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.IModelContainer;
@@ -25,6 +25,7 @@ import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -56,10 +57,9 @@ public class Relationship extends RdfModelObject implements Comparable<Relations
 		 relationshipType_hasPrerequisite
 	}
 	
-	public static HashMap<RelationshipType, String> RELATIONSHIP_TYPE_TO_TAG = 
-			new  HashMap<RelationshipType, String>();
-	public static HashMap<String, RelationshipType> TAG_TO_RELATIONSHIP_TYPE = 
-			new  HashMap<String, RelationshipType>();
+	public static Map<RelationshipType, String> RELATIONSHIP_TYPE_TO_TAG = Maps.newHashMap();
+	public static Map<String, RelationshipType> TAG_TO_RELATIONSHIP_TYPE = Maps.newHashMap();
+
 	static {
 		RELATIONSHIP_TYPE_TO_TAG.put(RelationshipType.relationshipType_describes, "DESCRIBES");
 		TAG_TO_RELATIONSHIP_TYPE.put("DESCRIBES", RelationshipType.relationshipType_describes);
@@ -301,7 +301,7 @@ public class Relationship extends RdfModelObject implements Comparable<Relations
 	
 	@Override
 	public Relationship clone() {
-		return clone(new HashMap<String, SpdxElement>());
+		return clone(Maps.<String, SpdxElement>newHashMap());
 	}
 	/* (non-Javadoc)
 	 * @see org.spdx.rdfparser.model.RdfModelObject#equivalent(org.spdx.rdfparser.model.RdfModelObject)
@@ -327,10 +327,10 @@ public class Relationship extends RdfModelObject implements Comparable<Relations
 	 * @param clonedElementIds
 	 * @return
 	 */
-	public Relationship clone(HashMap<String, SpdxElement> clonedElementIds) {
-		return new Relationship(this.relatedSpdxElement.clone(clonedElementIds),
-				this.relationshipType, this.comment);
+	public Relationship clone(Map<String, SpdxElement> clonedElementIds) {
+		return new Relationship(this.relatedSpdxElement.clone(clonedElementIds), this.relationshipType, this.comment);
 	}
+	
 	/* (non-Javadoc)
 	 * @see java.lang.Comparable#compareTo(java.lang.Object)
 	 */

--- a/src/org/spdx/rdfparser/model/SpdxElement.java
+++ b/src/org/spdx/rdfparser/model/SpdxElement.java
@@ -18,7 +18,8 @@ package org.spdx.rdfparser.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.IModelContainer;
@@ -27,6 +28,7 @@ import org.spdx.rdfparser.RdfModelHelper;
 import org.spdx.rdfparser.SpdxRdfConstants;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -146,10 +148,10 @@ public class SpdxElement extends RdfModelObject {
 	}
 	
 	/**
-	 * Add the name of the element to all strings in the arraylist
+	 * Add the name of the element to all strings in the list
 	 * @param warnings
 	 */
-	protected void addNameToWarnings(ArrayList<String> warnings) {
+	protected void addNameToWarnings(List<String> warnings) {
 		if (warnings == null) {
 			return;
 		}
@@ -347,7 +349,7 @@ public class SpdxElement extends RdfModelObject {
 		return clonedAnnotations;
 	}
 	
-	protected Relationship[] cloneRelationships(HashMap<String, SpdxElement> clonedElementIds) {
+	protected Relationship[] cloneRelationships(Map<String, SpdxElement> clonedElementIds) {
 		if (this.relationships == null) {
 			return null;
 		}
@@ -360,7 +362,7 @@ public class SpdxElement extends RdfModelObject {
 	
 	@Override
 	public SpdxElement clone() {
-		return clone(new HashMap<String, SpdxElement>());
+		return clone(Maps.<String, SpdxElement>newHashMap());
 	}
 	
 	/**
@@ -369,7 +371,7 @@ public class SpdxElement extends RdfModelObject {
 	 * @param clonedElementIds element ID's fo all elements which have been cloned
 	 * @return
 	 */
-	public SpdxElement clone(HashMap<String, SpdxElement> clonedElementIds) {
+	public SpdxElement clone(Map<String, SpdxElement> clonedElementIds) {
 		if (clonedElementIds.containsKey(this.getId())) {
 			return clonedElementIds.get(this.getId());
 		}

--- a/src/org/spdx/rdfparser/model/SpdxElementFactory.java
+++ b/src/org/spdx/rdfparser/model/SpdxElementFactory.java
@@ -16,13 +16,14 @@
 */
 package org.spdx.rdfparser.model;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxDocumentContainer;
 import org.spdx.rdfparser.SpdxRdfConstants;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.util.iterator.ExtendedIterator;
@@ -42,9 +43,9 @@ public class SpdxElementFactory {
 	 */
 	static void addToCreatedElements(IModelContainer modelContainer,
 			Node node, SpdxElement element) {
-		HashMap<Node, SpdxElement> containerNodes = createdElements.get(modelContainer);
+		Map<Node, SpdxElement> containerNodes = createdElements.get(modelContainer);
 		if (containerNodes == null) {
-			containerNodes = new HashMap<Node, SpdxElement>();
+			containerNodes = Maps.newHashMap();
 			createdElements.put(modelContainer, containerNodes);
 		}
 		containerNodes.put(node, element);
@@ -53,14 +54,13 @@ public class SpdxElementFactory {
 	 * Keep track of all nodes created both for performance and to prevent
 	 * an infinite recursion from continually creating the same objects.
 	 */
-	private static HashMap<IModelContainer, HashMap<Node, SpdxElement>> createdElements = 
-			new HashMap<IModelContainer, HashMap<Node, SpdxElement>>();
+	private static Map<IModelContainer, Map<Node, SpdxElement>> createdElements = Maps.newHashMap();
 
 	public static SpdxElement createElementFromModel(IModelContainer modelContainer,
 			Node node) throws InvalidSPDXAnalysisException {
-		HashMap<Node, SpdxElement> containerNodes = createdElements.get(modelContainer);
+		Map<Node, SpdxElement> containerNodes = createdElements.get(modelContainer);
 		if (containerNodes == null) {
-			containerNodes = new HashMap<Node, SpdxElement>();
+			containerNodes = Maps.newHashMap();
 			createdElements.put(modelContainer, containerNodes);
 		}
 		SpdxElement retval = containerNodes.get(node);

--- a/src/org/spdx/rdfparser/model/SpdxFile.java
+++ b/src/org/spdx/rdfparser/model/SpdxFile.java
@@ -18,7 +18,7 @@ package org.spdx.rdfparser.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.IModelContainer;
@@ -30,6 +30,7 @@ import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -51,8 +52,8 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 		fileType_image, fileType_other, fileType_source, fileType_spdx,
 		fileType_text, fileType_video};
 		
-	public static final HashMap<FileType, String> FILE_TYPE_TO_TAG = new HashMap<FileType, String>();
-	public static final HashMap<String, FileType> TAG_TO_FILE_TYPE = new HashMap<String, FileType>();
+	public static final Map<FileType, String> FILE_TYPE_TO_TAG = Maps.newHashMap();
+	public static final Map<String, FileType> TAG_TO_FILE_TYPE = Maps.newHashMap();
 	static {
 		FILE_TYPE_TO_TAG.put(FileType.fileType_application, "APPLICATION");
 		TAG_TO_FILE_TYPE.put("APPLICATION", FileType.fileType_application);
@@ -592,7 +593,7 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 		return retval;
 	}
 	
-	public SpdxFile[] cloneFileDependencies(HashMap<String, SpdxElement> clonedElementIds) {
+	public SpdxFile[] cloneFileDependencies(Map<String, SpdxElement> clonedElementIds) {
 		if (this.fileDependencies == null) {
 			return null;
 		}
@@ -604,7 +605,7 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 	}
 	
 	@Override
-    public SpdxFile clone(HashMap<String, SpdxElement> clonedElementIds) {
+    public SpdxFile clone(Map<String, SpdxElement> clonedElementIds) {
 		if (clonedElementIds.containsKey(this.getId())) {
 			return (SpdxFile)clonedElementIds.get(this.getId());
 		}
@@ -635,8 +636,9 @@ public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 		return retval;
 	}
 	
-	@Override public SpdxFile clone() {
-		return clone(new HashMap<String, SpdxElement>());
+	@Override 
+	public SpdxFile clone() {
+		return clone(Maps.<String, SpdxElement>newHashMap());
 	}
 	
 	@Override

--- a/src/org/spdx/rdfparser/model/SpdxItem.java
+++ b/src/org/spdx/rdfparser/model/SpdxItem.java
@@ -17,7 +17,7 @@
 package org.spdx.rdfparser.model;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
@@ -30,6 +30,7 @@ import org.spdx.rdfparser.license.SpdxNoAssertionLicense;
 import org.spdx.rdfparser.license.SpdxNoneLicense;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -284,11 +285,11 @@ public class SpdxItem extends SpdxElement {
 	
 	@Override
 	public SpdxItem clone() {
-		return clone(new HashMap<String, SpdxElement>());
+		return clone(Maps.<String, SpdxElement>newHashMap());
 	}
 	
 	@Override
-    public SpdxItem clone(HashMap<String, SpdxElement> clonedElementIds) {
+    public SpdxItem clone(Map<String, SpdxElement> clonedElementIds) {
 		if (clonedElementIds.containsKey(this.getId())) {
 			return (SpdxItem)clonedElementIds.get(this.getId());
 		}

--- a/src/org/spdx/rdfparser/model/SpdxPackage.java
+++ b/src/org/spdx/rdfparser/model/SpdxPackage.java
@@ -18,7 +18,7 @@ package org.spdx.rdfparser.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
@@ -31,6 +31,7 @@ import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -648,7 +649,7 @@ public class SpdxPackage extends SpdxItem implements SpdxRdfConstants, Comparabl
 	}
 	
 	@Override
-    public SpdxPackage clone(HashMap<String, SpdxElement> clonedElementIds) {
+    public SpdxPackage clone(Map<String, SpdxElement> clonedElementIds) {
 		if (clonedElementIds.containsKey(this.getId())) {
 			return (SpdxPackage)clonedElementIds.get(this.getId());
 		}
@@ -677,7 +678,7 @@ public class SpdxPackage extends SpdxItem implements SpdxRdfConstants, Comparabl
 	
 	@Override
 	public SpdxPackage clone() {
-		return clone(new HashMap<String, SpdxElement>());
+		return clone(Maps.<String, SpdxElement>newHashMap());
 	}
 
 	/**
@@ -694,7 +695,7 @@ public class SpdxPackage extends SpdxItem implements SpdxRdfConstants, Comparabl
 	/**
 	 * @return
 	 */
-	private SpdxFile[] cloneFiles(HashMap<String, SpdxElement> clonedElementIds) {
+	private SpdxFile[] cloneFiles(Map<String, SpdxElement> clonedElementIds) {
 		if (this.files == null) {
 			return new SpdxFile[0];
 		}

--- a/src/org/spdx/spdxspreadsheet/PerFileSheetV1d2.java
+++ b/src/org/spdx/spdxspreadsheet/PerFileSheetV1d2.java
@@ -16,7 +16,7 @@
 */
 package org.spdx.spdxspreadsheet;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -24,17 +24,19 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.spdx.compare.CompareHelper;
-import org.spdx.rdfparser.model.DoapProject;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxDocumentContainer;
+import org.spdx.rdfparser.license.AnyLicenseInfo;
+import org.spdx.rdfparser.license.LicenseInfoFactory;
 import org.spdx.rdfparser.model.Annotation;
 import org.spdx.rdfparser.model.Checksum;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
+import org.spdx.rdfparser.model.DoapProject;
 import org.spdx.rdfparser.model.Relationship;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxFile.FileType;
-import org.spdx.rdfparser.license.AnyLicenseInfo;
-import org.spdx.rdfparser.license.LicenseInfoFactory;
+
+import com.google.common.collect.Maps;
 
 /**
  * @author Gary O'Neall
@@ -83,9 +85,10 @@ public class PerFileSheetV1d2 extends PerFileSheet {
 	/**
 	 * Hashmap of the file name to SPDX file
 	 */
-	HashMap<String, SpdxFile> fileCache = new HashMap<String, SpdxFile>();
+	Map<String, SpdxFile> fileCache = Maps.newHashMap();
 	
-	@SuppressWarnings("deprecation")
+	@Override
+    @SuppressWarnings("deprecation")
 	public void add(SpdxFile fileInfo, String pkgId) {
 		Row row = addRow();
 		if (fileInfo.getArtifactOf() != null && fileInfo.getArtifactOf().length > 0) {
@@ -151,7 +154,8 @@ public class PerFileSheetV1d2 extends PerFileSheet {
 		}
 	}
 
-	@SuppressWarnings("deprecation")
+	@Override
+    @SuppressWarnings("deprecation")
 	public SpdxFile getFileInfo(int rowNum, SpdxDocumentContainer container) throws SpreadsheetException {
 		Row row = sheet.getRow(rowNum);
 		if (row == null) {

--- a/src/org/spdx/spdxspreadsheet/PerFileSheetV2d0.java
+++ b/src/org/spdx/spdxspreadsheet/PerFileSheetV2d0.java
@@ -16,7 +16,7 @@
 */
 package org.spdx.spdxspreadsheet;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -34,6 +34,8 @@ import org.spdx.rdfparser.model.DoapProject;
 import org.spdx.rdfparser.model.Relationship;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxFile.FileType;
+
+import com.google.common.collect.Maps;
 
 /**
  * @author Gary
@@ -80,9 +82,10 @@ public class PerFileSheetV2d0 extends PerFileSheet {
 	/**
 	 * Hashmap of the file name to SPDX file
 	 */
-	HashMap<String, SpdxFile> fileCache = new HashMap<String, SpdxFile>();
+	Map<String, SpdxFile> fileCache = Maps.newHashMap();
 	
-	@SuppressWarnings("deprecation")
+	@Override
+    @SuppressWarnings("deprecation")
 	public void add(SpdxFile fileInfo, String pkgId) {
 		Row row = addRow();
 		if (fileInfo.getId() != null && !fileInfo.getId().isEmpty()) {
@@ -154,7 +157,8 @@ public class PerFileSheetV2d0 extends PerFileSheet {
 		}
 	}
 
-	@SuppressWarnings("deprecation")
+	@Override
+    @SuppressWarnings("deprecation")
 	public SpdxFile getFileInfo(int rowNum, SpdxDocumentContainer container) throws SpreadsheetException {
 		Row row = sheet.getRow(rowNum);
 		if (row == null) {

--- a/src/org/spdx/tag/BuildDocument.java
+++ b/src/org/spdx/tag/BuildDocument.java
@@ -22,10 +22,10 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
@@ -55,6 +55,8 @@ import org.spdx.rdfparser.model.SpdxElement;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxFile.FileType;
 import org.spdx.rdfparser.model.SpdxPackage;
+
+import com.google.common.collect.Maps;
 
 /**
  * Translates an tag-value file to a an SPDX Document.
@@ -159,8 +161,7 @@ public class BuildDocument implements TagValueBehavior, Serializable {
     private DoapProject lastProject = null;
     // Keep track of all file dependencies since these need to be added after all of the files
     // have been parsed.  Map of file dependency file name to the SPDX files which depends on it
-    private HashMap<String, ArrayList<SpdxFile>> fileDependencyMap =
-            new HashMap<String, ArrayList<SpdxFile>>();
+    private Map<String, ArrayList<SpdxFile>> fileDependencyMap = Maps.newHashMap();
     /**
      * Keep track of the last relationship for any following relationship related tags
      */
@@ -960,8 +961,7 @@ public class BuildDocument implements TagValueBehavior, Serializable {
         // a new HashMap of files (as the key) and the dependency files (arraylist) as the values
         // Once that hashmap is built, the actual dependencies are then added.
         // the key contains an SPDX file with one or more dependencies.  The value is the array list of file dependencies
-        HashMap<SpdxFile, ArrayList<SpdxFile>> filesWithDependencies =
-                new HashMap<SpdxFile, ArrayList<SpdxFile>>();
+        Map<SpdxFile, ArrayList<SpdxFile>> filesWithDependencies = Maps.newHashMap();
         SpdxFile[] allFiles = analysis.getDocumentContainer().getFileReferences();
         // fill in the filesWithDependencies map
         for (int i = 0;i < allFiles.length; i++) {

--- a/src/org/spdx/tag/BuildLegacyDocument.java
+++ b/src/org/spdx/tag/BuildLegacyDocument.java
@@ -22,9 +22,9 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
@@ -34,15 +34,16 @@ import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SPDXCreatorInformation;
 import org.spdx.rdfparser.SPDXDocument;
 import org.spdx.rdfparser.SPDXDocument.SPDXPackage;
-import org.spdx.rdfparser.license.AnyLicenseInfo;
-import org.spdx.rdfparser.license.LicenseInfoFactory;
-import org.spdx.rdfparser.license.ExtractedLicenseInfo;
-import org.spdx.rdfparser.license.SpdxNoneLicense;
 import org.spdx.rdfparser.SPDXFile;
 import org.spdx.rdfparser.SPDXReview;
 import org.spdx.rdfparser.SpdxPackageVerificationCode;
 import org.spdx.rdfparser.SpdxRdfConstants;
+import org.spdx.rdfparser.license.AnyLicenseInfo;
+import org.spdx.rdfparser.license.ExtractedLicenseInfo;
+import org.spdx.rdfparser.license.LicenseInfoFactory;
+import org.spdx.rdfparser.license.SpdxNoneLicense;
 
+import com.google.common.collect.Maps;
 import com.hp.hpl.jena.rdf.model.Model;
 
 /**
@@ -72,8 +73,7 @@ public class BuildLegacyDocument implements TagValueBehavior, Serializable {
 	private DOAPProject lastProject = null;
 	// Keep track of all file dependencies since these need to be added after all of the files
 	// have been parsed.  Map of file dependency file name to the SPDX files which depends on it
-	private HashMap<String, ArrayList<SPDXFile>> fileDependencyMap = 
-		new HashMap<String, ArrayList<SPDXFile>>();
+	private Map<String, ArrayList<SPDXFile>> fileDependencyMap = Maps.newHashMap();
 
 	public BuildLegacyDocument(Model model, SPDXDocument spdxDocument, Properties constants) {
 		this.constants = constants;
@@ -88,11 +88,13 @@ public class BuildLegacyDocument implements TagValueBehavior, Serializable {
 		}
 	}
 
-	public void enter() throws Exception {
+	@Override
+    public void enter() throws Exception {
 		// do nothing???
 	}
 
-	public void buildDocument(String tag, String value) throws Exception {
+	@Override
+    public void buildDocument(String tag, String value) throws Exception {
 		tag = tag.trim()+" ";
 		value = trim(value.trim());
 		// document
@@ -370,7 +372,8 @@ public class BuildLegacyDocument implements TagValueBehavior, Serializable {
 		return value;
 	}
 
-	public void exit() throws Exception {
+	@Override
+    public void exit() throws Exception {
 		fixFileDependencies();
 		ArrayList<String> warningMessages = analysis.verify();
 		assertEquals("SPDXDocument", 0, warningMessages);
@@ -388,8 +391,7 @@ public class BuildLegacyDocument implements TagValueBehavior, Serializable {
 		// a new HashMap of files (as the key) and the dependency files (arraylist) as the values
 		// Once that hashmap is built, the actual dependencies are then added.
 		// the key contains an SPDX file with one or more dependencies.  The value is the array list of file dependencies
-		HashMap<SPDXFile, ArrayList<SPDXFile>> filesWithDependencies = 
-			new HashMap<SPDXFile, ArrayList<SPDXFile>>();
+		Map<SPDXFile, ArrayList<SPDXFile>> filesWithDependencies = Maps.newHashMap();
 		SPDXFile[] allFiles = analysis.getFileReferences();
 		// fill in the filesWithDependencies map
 		for (int i = 0;i < allFiles.length; i++) {

--- a/src/org/spdx/tools/CompareSpdxDocs.java
+++ b/src/org/spdx/tools/CompareSpdxDocs.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.spdx.compare.SpdxCompareException;
 import org.spdx.compare.SpdxComparer;
@@ -34,22 +35,22 @@ import org.spdx.compare.SpdxComparer.SPDXReviewDifference;
 import org.spdx.compare.SpdxFileDifference;
 import org.spdx.compare.SpdxLicenseDifference;
 import org.spdx.compare.SpdxPackageComparer;
-import org.spdx.rdfparser.model.DoapProject;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SPDXCreatorInformation;
 import org.spdx.rdfparser.SPDXDocumentFactory;
-import org.spdx.rdfparser.model.Annotation;
-import org.spdx.rdfparser.model.Checksum;
-import org.spdx.rdfparser.model.ExternalDocumentRef;
-import org.spdx.rdfparser.model.Relationship;
-import org.spdx.rdfparser.model.SpdxFile;
-import org.spdx.rdfparser.model.SpdxFile.FileType;
-import org.spdx.rdfparser.model.SpdxPackage;
 import org.spdx.rdfparser.SPDXReview;
 import org.spdx.rdfparser.SpdxPackageVerificationCode;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
+import org.spdx.rdfparser.model.Annotation;
+import org.spdx.rdfparser.model.Checksum;
+import org.spdx.rdfparser.model.DoapProject;
+import org.spdx.rdfparser.model.ExternalDocumentRef;
+import org.spdx.rdfparser.model.Relationship;
 import org.spdx.rdfparser.model.SpdxDocument;
+import org.spdx.rdfparser.model.SpdxFile;
+import org.spdx.rdfparser.model.SpdxFile.FileType;
+import org.spdx.rdfparser.model.SpdxPackage;
 
 /**
  * Command line application to compare two SPDX documents
@@ -181,12 +182,11 @@ public class CompareSpdxDocs {
 	}
 
 	/**
-	 * Prints an array list of strings
+	 * Prints a list of strings
 	 * @param list
 	 * @param output
 	 */
-	private static void printList(ArrayList<String> list,
-			PrintStream output) {
+	private static void printList(List<String> list, PrintStream output) {
 		for(int i = 0;i < list.size(); i++) {
 			output.println(list.get(i));
 		}

--- a/src/org/spdx/tools/LicenseRDFAGenerator.java
+++ b/src/org/spdx/tools/LicenseRDFAGenerator.java
@@ -20,30 +20,31 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.spdx.compare.LicenseCompareHelper;
 import org.spdx.html.ExceptionHtml;
 import org.spdx.html.ExceptionHtmlToc;
 import org.spdx.html.LicenseHTMLFile;
-import org.spdx.html.LicenseTOCJSONFile;
 import org.spdx.html.LicenseTOCHTMLFile;
+import org.spdx.html.LicenseTOCJSONFile;
 import org.spdx.licenseTemplate.LicenseTemplateRuleException;
 import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
 import org.spdx.rdfparser.license.ISpdxListedLicenseProvider;
+import org.spdx.rdfparser.license.LicenseException;
 import org.spdx.rdfparser.license.LicenseRestrictionException;
 import org.spdx.rdfparser.license.SpdxListedLicense;
-import org.spdx.rdfparser.license.LicenseException;
 import org.spdx.rdfparser.license.SpdxListedLicenseException;
 import org.spdx.spdxspreadsheet.SPDXLicenseSpreadsheet;
 import org.spdx.spdxspreadsheet.SPDXLicenseSpreadsheet.DeprecatedLicenseInfo;
 import org.spdx.spdxspreadsheet.SpreadsheetException;
 
-import com.google.common.io.Files;
 import com.github.mustachejava.MustacheException;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
 
 /**
  * Converts a spreadsheet containing SPDX License information into RDFA 
@@ -229,7 +230,7 @@ public class LicenseRDFAGenerator {
 		String exceptionHtmlTocReference = "./" + EXCEPTION_TOC_FILE_NAME;
 		ExceptionHtmlToc exceptionToc = new ExceptionHtmlToc();
 		Iterator<LicenseException> exceptionIter = licenseProvider.getExceptionIterator();
-		HashMap<String, String> addedExceptionsMap = new HashMap<String, String>();
+		Map<String, String> addedExceptionsMap = Maps.newHashMap();
 		while (exceptionIter.hasNext()) {
 			System.out.print(".");
 			LicenseException nextException = exceptionIter.next();
@@ -305,7 +306,7 @@ public class LicenseRDFAGenerator {
 		LicenseTOCHTMLFile tableOfContentsHTML = new LicenseTOCHTMLFile(version, releaseDate);
 		// Main page - License list
 		Iterator<SpdxListedLicense> licenseIter = licenseProvider.getLicenseIterator();
-		HashMap<String, String> addedLicIdTextMap = new HashMap<String, String>();
+		Map<String, String> addedLicIdTextMap = Maps.newHashMap();
 		while (licenseIter.hasNext()) {
 			System.out.print(".");
 			SpdxListedLicense license = licenseIter.next();

--- a/src/org/spdx/tools/RdfToHtml.java
+++ b/src/org/spdx/tools/RdfToHtml.java
@@ -21,9 +21,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.spdx.html.MustacheMap;
 import org.spdx.html.PackageContext;
@@ -35,9 +35,10 @@ import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxItem;
 import org.spdx.rdfparser.model.SpdxPackage;
 
-import com.github.mustachejava.Mustache;
 import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
+import com.google.common.collect.Maps;
 
 /**
  * Takes an input SPDX Document and produces the following HTML files in the specified directory:
@@ -193,7 +194,7 @@ public class RdfToHtml {
     		File docHtmlFile, File licenseHtmlFile, File docFilesHtmlFile) throws MustacheException, IOException, InvalidSPDXAnalysisException {
         String dirPath = docHtmlFile.getParent();
         DefaultMustacheFactory builder = new DefaultMustacheFactory(templateDirName);
-        HashMap<String, String> spdxIdToUrl = buildIdMap(doc, dirPath);
+        Map<String, String> spdxIdToUrl = buildIdMap(doc, dirPath);
         List<SpdxPackage> allPackages = doc.getDocumentContainer().findAllPackages();
         Iterator<SpdxPackage> pkgIter = allPackages.iterator();
         while (pkgIter.hasNext()) {
@@ -206,7 +207,7 @@ public class RdfToHtml {
 					PACKAGE_FILE_HTML_FILE_POSTFIX;
 			File packageFilesHtmlFile = new File(packageFilesHtmlFilePath);
         	PackageContext pkgContext = new PackageContext(pkg, spdxIdToUrl);
-        	HashMap<String, Object> pkgFileMap = MustacheMap.buildPkgFileMap(pkg, spdxIdToUrl);
+        	Map<String, Object> pkgFileMap = MustacheMap.buildPkgFileMap(pkg, spdxIdToUrl);
         	Mustache mustache = builder.compile(SPDX_PACKAGE_HTML_TEMPLATE);
         	FileWriter packageHtmlFileWriter = new FileWriter(packageHtmlFile);
         	try {
@@ -238,7 +239,7 @@ public class RdfToHtml {
         			files[fi++] = (SpdxFile)describedItems[i];
         		}
         	}
-        	HashMap<String, Object> docFileMap = MustacheMap.buildDocFileMustacheMap(
+        	Map<String, Object> docFileMap = MustacheMap.buildDocFileMustacheMap(
         			doc, files, spdxIdToUrl);
         	Mustache mustache = builder.compile(SPDX_FILE_HTML_TEMPLATE);
         	FileWriter docFilesHtmlFileWriter = new FileWriter(docFilesHtmlFile);
@@ -248,7 +249,7 @@ public class RdfToHtml {
         		docFilesHtmlFileWriter.close();
         	}
         }
-        HashMap<String, Object> extracteLicMustacheMap = MustacheMap.buildExtractedLicMustachMap(doc, spdxIdToUrl);
+        Map<String, Object> extracteLicMustacheMap = MustacheMap.buildExtractedLicMustachMap(doc, spdxIdToUrl);
         Mustache mustache = builder.compile(SPDX_LICENSE_HTML_TEMPLATE);
         FileWriter licenseHtmlFileWriter = new FileWriter(licenseHtmlFile);
         try {
@@ -256,7 +257,7 @@ public class RdfToHtml {
         } finally {
         	licenseHtmlFileWriter.close();
         }
-        HashMap<String, Object> docMustacheMap = MustacheMap.buildDocMustachMap(doc, spdxIdToUrl);
+        Map<String, Object> docMustacheMap = MustacheMap.buildDocMustachMap(doc, spdxIdToUrl);
         mustache = builder.compile(SPDX_DOCUMENT_HTML_TEMPLATE);
         FileWriter docHtmlFileWriter = new FileWriter(docHtmlFile);
         try {
@@ -274,10 +275,9 @@ public class RdfToHtml {
 	 * @return
 	 * @throws InvalidSPDXAnalysisException 
 	 */
-	private static HashMap<String, String> buildIdMap(SpdxDocument doc,
-			String dirPath) throws InvalidSPDXAnalysisException {
+	private static Map<String, String> buildIdMap(SpdxDocument doc, String dirPath) throws InvalidSPDXAnalysisException {
 		// URLs are all relative and use the ID as the part
-		HashMap<String, String> retval = new HashMap<String, String>();
+		Map<String, String> retval = Maps.newHashMap();
 		// extracted license IDs
 		String extractedLicenseFileName = doc.getName() + LICENSE_HTML_FILE_POSTFIX;
 		ExtractedLicenseInfo[] extractedLicenses = doc.getDocumentContainer().getExtractedLicenseInfos();

--- a/src/org/spdx/tools/RdfToSpreadsheet.java
+++ b/src/org/spdx/tools/RdfToSpreadsheet.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -33,25 +32,27 @@ import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
+import org.spdx.rdfparser.SPDXDocumentFactory;
+import org.spdx.rdfparser.SPDXReview;
+import org.spdx.rdfparser.SpdxRdfConstants;
+import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.model.Annotation;
 import org.spdx.rdfparser.model.Relationship;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxElement;
-import org.spdx.rdfparser.model.SpdxPackage;
-import org.spdx.rdfparser.license.ExtractedLicenseInfo;
-import org.spdx.rdfparser.SPDXDocumentFactory;
 import org.spdx.rdfparser.model.SpdxFile;
-import org.spdx.rdfparser.SPDXReview;
-import org.spdx.rdfparser.SpdxRdfConstants;
+import org.spdx.rdfparser.model.SpdxPackage;
 import org.spdx.spdxspreadsheet.AnnotationsSheet;
-import org.spdx.spdxspreadsheet.NonStandardLicensesSheet;
 import org.spdx.spdxspreadsheet.DocumentInfoSheet;
+import org.spdx.spdxspreadsheet.NonStandardLicensesSheet;
 import org.spdx.spdxspreadsheet.PackageInfoSheet;
 import org.spdx.spdxspreadsheet.PerFileSheet;
 import org.spdx.spdxspreadsheet.RelationshipsSheet;
 import org.spdx.spdxspreadsheet.ReviewersSheet;
 import org.spdx.spdxspreadsheet.SPDXSpreadsheet;
 import org.spdx.spdxspreadsheet.SpreadsheetException;
+
+import com.google.common.collect.Maps;
 
 /**
  * Translates an RDF XML file to a SPDX Spreadsheet format
@@ -134,7 +135,7 @@ public class RdfToSpreadsheet {
 			return;
 		}
 		copyOrigins(doc, ss.getOriginsSheet());
-		HashMap<String, String> fileIdToPackageId = copyPackageInfo(doc.getDocumentContainer().findAllPackages(), ss.getPackageInfoSheet());
+		Map<String, String> fileIdToPackageId = copyPackageInfo(doc.getDocumentContainer().findAllPackages(), ss.getPackageInfoSheet());
 		copyNonStdLicenses(doc.getExtractedLicenseInfos(), ss.getNonStandardLicensesSheet());
 		copyPerFileInfo(doc.getDocumentContainer().findAllFiles(), ss.getPerFileSheet(), fileIdToPackageId);
 		Map<String, Relationship[]> allRelationships = new TreeMap<String, Relationship[]>();
@@ -203,7 +204,7 @@ public class RdfToSpreadsheet {
 	}
 
 	private static void copyPerFileInfo(List<SpdxFile> fileList,
-			PerFileSheet perFileSheet, HashMap<String, String> fileIdToPackageId) {            
+			PerFileSheet perFileSheet, Map<String, String> fileIdToPackageId) {            
             Collections.sort(fileList);
             /* Print out sorted files */            
 		for (SpdxFile file : fileList) {
@@ -221,9 +222,9 @@ public class RdfToSpreadsheet {
 		}
 	}
 
-	private static HashMap<String, String> copyPackageInfo(List<SpdxPackage> packages,
+	private static Map<String, String> copyPackageInfo(List<SpdxPackage> packages,
 			PackageInfoSheet packageInfoSheet) throws InvalidSPDXAnalysisException {
-		HashMap<String, String> fileIdToPkgId = new HashMap<String, String>();
+		Map<String, String> fileIdToPkgId = Maps.newHashMap();
 		Collections.sort(packages);
 		Iterator<SpdxPackage> iter = packages.iterator();
 		while (iter.hasNext()) {

--- a/src/org/spdx/tools/SpreadsheetToRDF.java
+++ b/src/org/spdx/tools/SpreadsheetToRDF.java
@@ -24,11 +24,18 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SPDXCreatorInformation;
+import org.spdx.rdfparser.SPDXReview;
+import org.spdx.rdfparser.SpdxDocumentContainer;
+import org.spdx.rdfparser.SpdxRdfConstants;
+import org.spdx.rdfparser.SpdxVerificationHelper;
+import org.spdx.rdfparser.license.ExtractedLicenseInfo;
+import org.spdx.rdfparser.license.LicenseInfoFactory;
+import org.spdx.rdfparser.license.SpdxListedLicense;
 import org.spdx.rdfparser.model.Annotation;
 import org.spdx.rdfparser.model.ExternalDocumentRef;
 import org.spdx.rdfparser.model.Relationship;
@@ -36,23 +43,18 @@ import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxElement;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.rdfparser.model.SpdxPackage;
-import org.spdx.rdfparser.SpdxDocumentContainer;
-import org.spdx.rdfparser.license.LicenseInfoFactory;
-import org.spdx.rdfparser.license.ExtractedLicenseInfo;
-import org.spdx.rdfparser.license.SpdxListedLicense;
-import org.spdx.rdfparser.SPDXReview;
-import org.spdx.rdfparser.SpdxRdfConstants;
-import org.spdx.rdfparser.SpdxVerificationHelper;
 import org.spdx.spdxspreadsheet.AnnotationsSheet;
+import org.spdx.spdxspreadsheet.DocumentInfoSheet;
 import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
 import org.spdx.spdxspreadsheet.NonStandardLicensesSheet;
-import org.spdx.spdxspreadsheet.DocumentInfoSheet;
 import org.spdx.spdxspreadsheet.PackageInfoSheet;
 import org.spdx.spdxspreadsheet.PerFileSheet;
 import org.spdx.spdxspreadsheet.RelationshipsSheet;
 import org.spdx.spdxspreadsheet.ReviewersSheet;
 import org.spdx.spdxspreadsheet.SPDXSpreadsheet;
 import org.spdx.spdxspreadsheet.SpreadsheetException;
+
+import com.google.common.collect.Maps;
 
 /**
  * Converts a spreadsheet to an SPDX RDF Analysis file
@@ -169,7 +171,7 @@ public class SpreadsheetToRDF {
 		copyOrigins(ss.getOriginsSheet(), analysis);
 		copyNonStdLicenses(ss.getNonStandardLicensesSheet(), analysis);
 		// note - non std licenses must be added first so that the text is available
-		HashMap<String, SpdxPackage> pkgIdToPackage = copyPackageInfo(ss.getPackageInfoSheet(), analysis);
+		Map<String, SpdxPackage> pkgIdToPackage = copyPackageInfo(ss.getPackageInfoSheet(), analysis);
 		// note - packages need to be added before the files so that the files can be added to the packages
 		copyPerFileInfo(ss.getPerFileSheet(), analysis, pkgIdToPackage);
 		copyAnnotationInfo(ss.getAnnotationsSheet(), analysis);
@@ -233,7 +235,7 @@ public class SpreadsheetToRDF {
 	}
 
 	private static void copyPerFileInfo(PerFileSheet perFileSheet,
-			SpdxDocument analysis, HashMap<String, SpdxPackage> pkgIdToPackage) throws SpreadsheetException, InvalidSPDXAnalysisException {
+			SpdxDocument analysis, Map<String, SpdxPackage> pkgIdToPackage) throws SpreadsheetException, InvalidSPDXAnalysisException {
 		int firstRow = perFileSheet.getFirstDataRow();
 		int numFiles = perFileSheet.getNumDataRows();
 		for (int i = 0; i < numFiles; i++) {
@@ -270,10 +272,10 @@ public class SpreadsheetToRDF {
 		analysis.setExtractedLicenseInfos(nonStdLicenses);
 	}
 
-	private static HashMap<String, SpdxPackage> copyPackageInfo(PackageInfoSheet packageInfoSheet,
+	private static Map<String, SpdxPackage> copyPackageInfo(PackageInfoSheet packageInfoSheet,
 			SpdxDocument analysis) throws SpreadsheetException, InvalidSPDXAnalysisException {
 		SpdxPackage[] packages = packageInfoSheet.getPackages(analysis.getDocumentContainer());
-		HashMap<String, SpdxPackage> pkgIdToPackage = new HashMap<String, SpdxPackage>();
+		Map<String, SpdxPackage> pkgIdToPackage = Maps.newHashMap();
 		for (int i = 0; i < packages.length; i++) {
 			pkgIdToPackage.put(packages[i].getId(), packages[i]);
 			analysis.getDocumentContainer().addElement(packages[i]);


### PR DESCRIPTION
Enforce better decoupling by having APIs and variables take/be instances of the Map interface instead of directly referencing HashMap.

Since HashMap implements map, all changes should be backwards compatible

My contributions are licensed under the Apache 2.0 License as required by contributions to this project