### PR TITLE
Remove direct references to TreeSet in favor of Set

### DIFF
--- a/src/org/spdx/rdfparser/VerificationCodeGenerator.java
+++ b/src/org/spdx/rdfparser/VerificationCodeGenerator.java
@@ -25,9 +25,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.TreeSet;
+import java.util.Set;
 
 import org.spdx.rdfparser.model.SpdxFile;
+
+import com.google.common.collect.Sets;
 
 /**
  * Generates a package verification code from a directory of source code or an array of <code>SPDXFile</code>s.  
@@ -60,7 +62,7 @@ public class VerificationCodeGenerator {
 		if (spdxFiles == null) {
 			return null;
 		}
-		TreeSet<String> skippedFilePathSet = new TreeSet<String>();
+		Set<String> skippedFilePathSet = Sets.newTreeSet();
 		if (skippedFilePaths != null) {
 			for (int i = 0; i < skippedFilePaths.length; i++) {
 				if (skippedFilePaths[i] != null) {
@@ -90,7 +92,7 @@ public class VerificationCodeGenerator {
 		if (spdxFiles == null) {
 			return null;
 		}
-		TreeSet<String> skippedFilePathSet = new TreeSet<String>();
+		Set<String> skippedFilePathSet = Sets.newTreeSet();
 		if (skippedFilePaths != null) {
 			for (int i = 0; i < skippedFilePaths.length; i++) {
 				if (skippedFilePaths[i] != null) {
@@ -119,7 +121,7 @@ public class VerificationCodeGenerator {
 	 */
 	public SpdxPackageVerificationCode generatePackageVerificationCode(File sourceDirectory, File[] skippedFiles) throws NoSuchAlgorithmException, IOException {
 		// create a sorted list of file paths
-		TreeSet<String> skippedFilesPath = new TreeSet<String>();
+		Set<String> skippedFilesPath = Sets.newTreeSet();
 		String rootOfDirectory = sourceDirectory.getAbsolutePath();
 		int rootLen = rootOfDirectory.length()+1;
 		for (int i = 0; i < skippedFiles.length; i++) {
@@ -158,7 +160,7 @@ public class VerificationCodeGenerator {
 	 * @throws IOException 
 	 */
 	private void collectFileData(String prefixForRelative, File sourceDirectory,
-			ArrayList<String> fileNameAndChecksums, TreeSet<String> skippedFiles) throws IOException {
+			ArrayList<String> fileNameAndChecksums, Set<String> skippedFiles) throws IOException {
 		if (!sourceDirectory.isDirectory()) {
 			return;
 		}


### PR DESCRIPTION
Improve compliance with Java coding practices by replacing direct declarations of TreeSet with Set

TestFiles occurrences were ignored for now - I will update them after all pending pull requests are resolved

My contributions are licensed under Apache 2.0 License as required for contributions to this project