### PR TITLE
Replace No-Op instanceof checks

### DIFF
--- a/src/org/spdx/compare/DocumentAnnotationSheet.java
+++ b/src/org/spdx/compare/DocumentAnnotationSheet.java
@@ -42,10 +42,10 @@ public class DocumentAnnotationSheet extends AbstractSheet {
 		 */
 		@Override
 		public int compare(Annotation o1, Annotation o2) {
-			if (o1 instanceof Annotation) {
-				if (o2 instanceof Annotation) {
-					Annotation a1 = (Annotation)o1;
-					Annotation a2 = (Annotation)o2;
+			if (o1 != null) {
+				if (o2 != null) {
+					Annotation a1 = o1;
+					Annotation a2 = o2;
 					int retval = a1.getAnnotator().compareTo(a2.getAnnotator());
 					if (retval != 0) {
 						return retval;

--- a/src/org/spdx/compare/DocumentRelationshipSheet.java
+++ b/src/org/spdx/compare/DocumentRelationshipSheet.java
@@ -42,10 +42,10 @@ public class DocumentRelationshipSheet extends AbstractSheet {
 		 */
 		@Override
 		public int compare(Relationship o1, Relationship o2) {
-			if (o1 instanceof Relationship) {
-				if (o2 instanceof Relationship) {
-					Relationship r1 = (Relationship)o1;
-					Relationship r2 = (Relationship)o2;
+			if (o1 != null) {
+				if (o2 != null) {
+					Relationship r1 = o1;
+					Relationship r2 = o2;
 					int retval = r1.getRelationshipType().toString().compareTo(r2.getRelationshipType().toString());
 					if (retval != 0) {
 						return retval;

--- a/src/org/spdx/compare/ExternalReferencesSheet.java
+++ b/src/org/spdx/compare/ExternalReferencesSheet.java
@@ -45,8 +45,8 @@ public class ExternalReferencesSheet extends AbstractSheet {
 		 */
 		@Override
 		public int compare(ExternalDocumentRef o1, ExternalDocumentRef o2) {
-			if (o1 instanceof ExternalDocumentRef) {
-				if (o2 instanceof ExternalDocumentRef) {
+			if (o1 != null) {
+				if (o2 != null) {
 					ExternalDocumentRef r1 = o1;
 					ExternalDocumentRef r2 = o2;
 					int retval = r1.getSpdxDocumentNamespace().compareTo((r2.getSpdxDocumentNamespace()));

--- a/src/org/spdx/html/MustacheMap.java
+++ b/src/org/spdx/html/MustacheMap.java
@@ -270,7 +270,7 @@ public class MustacheMap {
 		});
 		List<FileContext> alFiles = Lists.newArrayList();
 		for (int i = 0; i < files.length; i++) {
-			if (files[i] instanceof SpdxFile) {
+			if (files[i] != null) {
 				alFiles.add(new FileContext(files[i]));
 			}
 		}


### PR DESCRIPTION
There are several instanceof uses checking that the variable is an instance of the class it is passed in as - these only serve as a not-null check, and should be written as such

My contributions are licensed under the Apache 2.0 license as required for contributions to this project