### PR TITLE
Prevent NPEs when closing IOStreams and reading a list

### DIFF
--- a/src/org/spdx/compare/MultiDocumentSpreadsheet.java
+++ b/src/org/spdx/compare/MultiDocumentSpreadsheet.java
@@ -206,7 +206,9 @@ public class MultiDocumentSpreadsheet extends AbstractSpreadsheet {
 			VerificationSheet.create(wb, VERIFICATION_SHEET_NAME);
 			wb.write(excelOut);
 		} finally {
-			excelOut.close();
+		    if(excelOut != null){
+		        excelOut.close();
+		    }
 		}
 	}
 	

--- a/src/org/spdx/spdxspreadsheet/SPDXLicenseSpreadsheet.java
+++ b/src/org/spdx/spdxspreadsheet/SPDXLicenseSpreadsheet.java
@@ -25,9 +25,9 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.license.ISpdxListedLicenseProvider;
+import org.spdx.rdfparser.license.LicenseException;
 import org.spdx.rdfparser.license.LicenseRestrictionException;
 import org.spdx.rdfparser.license.SpdxListedLicense;
-import org.spdx.rdfparser.license.LicenseException;
 
 /**
  * A spreadhseet containing license information
@@ -217,7 +217,9 @@ public class SPDXLicenseSpreadsheet extends AbstractSpreadsheet implements ISpdx
 			DeprecatedLicenseSheet.create(wb, DEPRECATED_SHEET_NAME);
 			wb.write(excelOut);
 		} finally {
-			excelOut.close();
+		    if(excelOut != null){
+		        excelOut.close();
+		    }
 		}
 	}
 
@@ -254,7 +256,8 @@ public class SPDXLicenseSpreadsheet extends AbstractSpreadsheet implements ISpdx
 		return licenseSheet;
 	}
 
-	public Iterator<SpdxListedLicense> getLicenseIterator() {
+	@Override
+    public Iterator<SpdxListedLicense> getLicenseIterator() {
 		try {
             return new LicenseIterator();
         } catch (SpreadsheetException e) {
@@ -262,7 +265,8 @@ public class SPDXLicenseSpreadsheet extends AbstractSpreadsheet implements ISpdx
         }
 	}
 	
-	public Iterator<DeprecatedLicenseInfo> getDeprecatedLicenseIterator() {
+	@Override
+    public Iterator<DeprecatedLicenseInfo> getDeprecatedLicenseIterator() {
 		try {
             return new DeprecatedLicenseIterator();
         } catch (SpreadsheetException e) {

--- a/src/org/spdx/spdxspreadsheet/SPDXSpreadsheet.java
+++ b/src/org/spdx/spdxspreadsheet/SPDXSpreadsheet.java
@@ -168,7 +168,9 @@ public class SPDXSpreadsheet extends AbstractSpreadsheet {
 			ReviewersSheet.create(wb, REVIEWERS_SHEET_NAME);
 			wb.write(excelOut);
 		} finally {
-			excelOut.close();
+		    if(excelOut != null){
+		        excelOut.close();
+		    }
 		}
 	}
 

--- a/src/org/spdx/tools/RdfToSpreadsheet.java
+++ b/src/org/spdx/tools/RdfToSpreadsheet.java
@@ -103,7 +103,7 @@ public class RdfToSpreadsheet {
 			ss = new SPDXSpreadsheet(spdxSpreadsheetFile, true, false);
 			copyRdfXmlToSpreadsheet(doc, ss);
 			List<String> verify = doc.verify();
-			if (verify.size() > 0) {
+			if (verify != null && verify.size() > 0) {
 				System.out.println("Warning: The following verifications failed for the resultant SPDX RDF file:");
 				for (int i = 0; i < verify.size(); i++) {
 					System.out.println("\t"+verify.get(i));


### PR DESCRIPTION
There are several locations where a failed stream creation could be masked by an NPE when the tools attempt to close the stream in a finally block.

My contributions are licensed under the Apache 2.0 License as required for contributions to this project