### PR TITLE
Make inner classes static when possible

### DIFF
--- a/src/org/spdx/compare/DocumentAnnotationSheet.java
+++ b/src/org/spdx/compare/DocumentAnnotationSheet.java
@@ -35,7 +35,7 @@ import org.spdx.spdxspreadsheet.AbstractSheet;
  */
 public class DocumentAnnotationSheet extends AbstractSheet {
 	
-	class AnnotationComparator implements Comparator<Annotation> {
+	private static class AnnotationComparator implements Comparator<Annotation> {
 
 		/* (non-Javadoc)
 		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)

--- a/src/org/spdx/compare/DocumentRelationshipSheet.java
+++ b/src/org/spdx/compare/DocumentRelationshipSheet.java
@@ -35,7 +35,7 @@ import org.spdx.spdxspreadsheet.AbstractSheet;
  */
 public class DocumentRelationshipSheet extends AbstractSheet {
 
-	class RelationshipComparator implements Comparator<Relationship> {
+	private static class RelationshipComparator implements Comparator<Relationship> {
 
 		/* (non-Javadoc)
 		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)

--- a/src/org/spdx/compare/ExternalReferencesSheet.java
+++ b/src/org/spdx/compare/ExternalReferencesSheet.java
@@ -38,7 +38,7 @@ import com.google.common.base.Objects;
  */
 public class ExternalReferencesSheet extends AbstractSheet {
 	
-	class ExternalDocRefComparator implements Comparator<ExternalDocumentRef> {
+	private static class ExternalDocRefComparator implements Comparator<ExternalDocumentRef> {
 
 		/* (non-Javadoc)
 		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)

--- a/src/org/spdx/compare/ExtractedLicenseSheet.java
+++ b/src/org/spdx/compare/ExtractedLicenseSheet.java
@@ -39,7 +39,7 @@ import org.spdx.spdxspreadsheet.AbstractSheet;
  */
 public class ExtractedLicenseSheet extends AbstractSheet {
 	
-	class ExtractedLicenseComparator implements Comparator<AnyLicenseInfo> {
+	private static final class ExtractedLicenseComparator implements Comparator<AnyLicenseInfo> {
 
 		/* (non-Javadoc)
 		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)

--- a/src/org/spdx/compare/MultiDocumentSpreadsheet.java
+++ b/src/org/spdx/compare/MultiDocumentSpreadsheet.java
@@ -56,7 +56,7 @@ import org.spdx.spdxspreadsheet.SpreadsheetException;
  */
 public class MultiDocumentSpreadsheet extends AbstractSpreadsheet {
 	
-	class SpdxFileComparator implements Comparator<SpdxFile> {
+	private static final class SpdxFileComparator implements Comparator<SpdxFile> {
 		
 		private NormalizedFileNameComparator normalizedFileNameComparator = new NormalizedFileNameComparator();
 

--- a/src/org/spdx/compare/ReviewerSheet.java
+++ b/src/org/spdx/compare/ReviewerSheet.java
@@ -39,7 +39,7 @@ import org.spdx.spdxspreadsheet.AbstractSheet;
  */
 public class ReviewerSheet extends AbstractSheet {
 	
-	class ReviewerComparator implements Comparator<SPDXReview> {
+	private static final class ReviewerComparator implements Comparator<SPDXReview> {
 
 		/* (non-Javadoc)
 		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)

--- a/src/org/spdx/compare/SpdxComparer.java
+++ b/src/org/spdx/compare/SpdxComparer.java
@@ -80,7 +80,7 @@ public class SpdxComparer {
 	 * @author Gary O'Neall
 	 *
 	 */
-	public class SPDXReviewDifference {
+	public static class SPDXReviewDifference {
 		
 		boolean commentsEqual;
 		boolean datesEqual;

--- a/src/org/spdx/compare/SpdxFileComparer.java
+++ b/src/org/spdx/compare/SpdxFileComparer.java
@@ -70,7 +70,7 @@ public class SpdxFileComparer extends SpdxItemComparer {
 	 * @author Gary O'Neall
 	 *
 	 */
-	class DoapComparator implements Comparator<DoapProject> {
+	private static class DoapComparator implements Comparator<DoapProject> {
 
 		/* (non-Javadoc)
 		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)

--- a/src/org/spdx/html/ExceptionHtmlToc.java
+++ b/src/org/spdx/html/ExceptionHtmlToc.java
@@ -47,7 +47,7 @@ public class ExceptionHtmlToc {
 	 * @author Gary O'Neall
 	 *
 	 */
-	public class ExceptionRow {
+	public static class ExceptionRow {
 		private int refNumber;
 		private String reference;
 		private String exceptionName;

--- a/src/org/spdx/html/LicenseHTMLFile.java
+++ b/src/org/spdx/html/LicenseHTMLFile.java
@@ -58,7 +58,7 @@ public class LicenseHTMLFile {
 	 * @author Gary O'Neall
 	 *
 	 */
-	public class FormattedUrl {
+	public static class FormattedUrl {
 		String url;
 		public FormattedUrl(String url) {
 			this.url = url;

--- a/src/org/spdx/html/LicenseTOCHTMLFile.java
+++ b/src/org/spdx/html/LicenseTOCHTMLFile.java
@@ -43,7 +43,7 @@ public class LicenseTOCHTMLFile {
 	static final String TEMPLATE_ROOT_PATH = "resources" + File.separator + "htmlTemplate";
 	static final String HTML_TEMPLATE = "TocHTMLTemplate.html";
 
-	public class DeprecatedLicense {
+	public static class DeprecatedLicense {
 		private String reference;
 		private String refNumber;
 		private String licenseId;

--- a/src/org/spdx/html/LicenseTOCJSONFile.java
+++ b/src/org/spdx/html/LicenseTOCJSONFile.java
@@ -35,20 +35,12 @@ import com.google.common.collect.Lists;
  */
 public class LicenseTOCJSONFile {
 	
-	public class ListedSpdxLicense {
-		private String reference;
-		private String refNumber;
-		private String licenseId;
-		private boolean osiApproved;
-		private String licenseName;
-		
-		public ListedSpdxLicense() {
-			reference = null;
-			refNumber = null;
-			licenseId = null;
-			osiApproved = false;
-			licenseName = null;
-		}
+	private static class ListedSpdxLicense {
+		private final String reference;
+		private final String refNumber;
+		private final String licenseId;
+		private final boolean osiApproved;
+		private final String licenseName;
 		
 		public ListedSpdxLicense(String reference, String refNumber, 
 				String licenseId, boolean osiApproved, String licenseName) {
@@ -63,41 +55,22 @@ public class LicenseTOCJSONFile {
 			return reference;
 		}
 
-		public void setReference(String reference) {
-			this.reference = reference;
-		}
-
 		public String getRefNumber() {
 			return refNumber;
-		}
-
-		public void setRefNumber(String refNumber) {
-			this.refNumber = refNumber;
 		}
 
 		public String getLicenseId() {
 			return licenseId;
 		}
 
-		public void setLicenseId(String licenseId) {
-			this.licenseId = licenseId;
-		}
-
 		public boolean getOsiApproved() {
 			return osiApproved;
-		}
-
-		public void setOsiApproved(boolean osiApproved) {
-			this.osiApproved = osiApproved;
 		}
 
 		public String getLicenseName() {
 			return licenseName;
 		}
 
-		public void setLicenseName(String licenseName) {
-			this.licenseName = licenseName;
-		}
 	}
 	
 	List<ListedSpdxLicense> listedLicenses = Lists.newArrayList();

--- a/src/org/spdx/rdfparser/license/SpdxLicenseCsv.java
+++ b/src/org/spdx/rdfparser/license/SpdxLicenseCsv.java
@@ -60,7 +60,7 @@ public class SpdxLicenseCsv implements ISpdxListedLicenseProvider {
 	private static final int NUM_COLS = HEADER_ROW.length;
 
 	
-	class CsvLicenseIterator implements Iterator<SpdxListedLicense> {
+	private static class CsvLicenseIterator implements Iterator<SpdxListedLicense> {
 		
 		private CSVReader iterReader = null;
 		SpdxListedLicense nextStandardLicense = null;

--- a/src/org/spdx/spdxspreadsheet/SPDXLicenseSpreadsheet.java
+++ b/src/org/spdx/spdxspreadsheet/SPDXLicenseSpreadsheet.java
@@ -99,7 +99,7 @@ public class SPDXLicenseSpreadsheet extends AbstractSpreadsheet implements ISpdx
 		}		
 	}
 	
-	public class DeprecatedLicenseInfo {
+	public static class DeprecatedLicenseInfo {
 		private SpdxListedLicense license;
 		private String deprecatedVersion;
 		public DeprecatedLicenseInfo(SpdxListedLicense license, String deprecatedVersion) {

--- a/src/org/spdx/tag/BuildDocument.java
+++ b/src/org/spdx/tag/BuildDocument.java
@@ -69,7 +69,7 @@ import com.google.common.collect.Sets;
  */
 public class BuildDocument implements TagValueBehavior, Serializable {
 
-    class AnnotationWithId {
+    private static class AnnotationWithId {
         private Annotation annotation;
         private String id;
         private AnnotationWithId(String annotator) {
@@ -97,7 +97,7 @@ public class BuildDocument implements TagValueBehavior, Serializable {
             return this.annotation;
         }
     }
-    class RelationshipWithId {
+    private static class RelationshipWithId {
         private String id;
         private String relatedId;
         private RelationshipType relationshipType;


### PR DESCRIPTION
When possible, inner classes should be static to prevent Java from unnecessarily keeping a reference to the containing class's instance (and to not require an instance of the containing class to create one). An inner class may be static if it does not need to reference any of the state variables of the containing class

My contributions are licensed under the Apache 2.0 License as required for contributions to this project