### PR TITLE
Fix an issue in SPDXCreatorInformation.equals 

### DIFF
--- a/src/org/spdx/rdfparser/SPDXCreatorInformation.java
+++ b/src/org/spdx/rdfparser/SPDXCreatorInformation.java
@@ -242,8 +242,8 @@ public class SPDXCreatorInformation {
 			}
 		} else if (this.createdDate == null) {
 			return false;
-		}
-			else if (!compCreator.getCreated().equals(this.createdDate)) {
+		} else if (!compCreator.getCreated().equals(this.createdDate)) {
+			    return false;
 		}
 		if (compCreator.getComment() == null) {
 			if (this.getComment() != null) {


### PR DESCRIPTION
This request resolves issue #41 by adding the missing logic in the check for non-null, unequal create date values

My contributions are licensed under the Apache 2.0 License as required for contributions to this project