### PR TITLE
Fix erroneous self-comparison in LicenseException

### DIFF
--- a/src/org/spdx/rdfparser/license/LicenseException.java
+++ b/src/org/spdx/rdfparser/license/LicenseException.java
@@ -173,7 +173,7 @@ public class LicenseException implements IRdfModel  {
 		if (this.model != null &&
 				this.exceptionNode != null &&
 				this.resource != null &&
-				(this.model.equals(model) || (this.exceptionNode.isURI()))) {
+				(this.model.equals(modelContainer.getModel()) || (this.exceptionNode.isURI()))) {
 			return resource;
 		} else {
 			this.model = modelContainer.getModel();


### PR DESCRIPTION
There is a comparison in LicenseException where it checks if this.model is equal to this.model - which will always be true. Based on the code following this statement, it appears this comparison was intended to be the input values getModel() call being compared to the contained model instance instead.

My contributions are licensed under the Apache 2.0 License as required for contributions to this project