### PR TITLE
Improve multi-thread synchronization consistency

### DIFF
--- a/src/org/spdx/rdfparser/SPDXDocument.java
+++ b/src/org/spdx/rdfparser/SPDXDocument.java
@@ -19,6 +19,7 @@ package org.spdx.rdfparser;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 
 import org.spdx.rdfparser.license.AnyLicenseInfo;
@@ -86,7 +87,7 @@ public class SPDXDocument implements SpdxRdfConstants, IModelContainer {
 	 * Keeps tract of the next license reference number when generating the license ID's for
 	 * non-standard licenses
 	 */
-	protected int nextLicenseRef = 1;
+	private AtomicInteger nextLicenseRef = new AtomicInteger(1);
 	
 	/**
 	 * Simple class representing an SPDX Package.  This is stored in an RDF
@@ -904,7 +905,7 @@ public class SPDXDocument implements SpdxRdfConstants, IModelContainer {
 	 * Namespace for all SPDX document elements
 	 */
 	private String documentNamespace;
-	private int nextElementRef;
+	private AtomicInteger nextElementRef = new AtomicInteger(0);
 	
 	public SPDXDocument(Model model) throws InvalidSPDXAnalysisException {
 		this.model = model;
@@ -970,7 +971,7 @@ public class SPDXDocument implements SpdxRdfConstants, IModelContainer {
 			}
 		}
 		
-		this.nextElementRef = highestElementRef + 1;
+		this.nextElementRef.set(highestElementRef + 1);
 	}
 
 	/**
@@ -1007,7 +1008,7 @@ public class SPDXDocument implements SpdxRdfConstants, IModelContainer {
 				// just continue
 			}
 		}	
-		this.nextLicenseRef = highestNonStdLicense + 1;
+		this.nextLicenseRef.set(highestNonStdLicense + 1);
 	}
 	
 	/**
@@ -1033,12 +1034,6 @@ public class SPDXDocument implements SpdxRdfConstants, IModelContainer {
 	
 	public static String formNonStandardLicenseID(int idNum) {
 		return NON_STD_LICENSE_ID_PRENUM + String.valueOf(idNum);
-	}
-	
-	synchronized int getAndIncrementNextLicenseRef() {
-		int retval = this.nextLicenseRef;
-		this.nextLicenseRef++;
-		return retval;
 	}
 
 	public String verifySpdxVersion(String spdxVersion) {
@@ -1690,7 +1685,7 @@ public class SPDXDocument implements SpdxRdfConstants, IModelContainer {
 	 * @return next available license ID for an ExtractedLicenseInfo
 	 */
 	public synchronized String getNextLicenseRef() {
-		int nextLicNum = this.getAndIncrementNextLicenseRef();
+		int nextLicNum = this.nextLicenseRef.getAndIncrement();
 		return formNonStandardLicenseID(nextLicNum);
 	}
 	
@@ -1699,21 +1694,12 @@ public class SPDXDocument implements SpdxRdfConstants, IModelContainer {
 	 */
 	@Override
 	public String getNextSpdxElementRef() {
-		int nextSpdxElementNum = this.getAndIncrementNextElementRef();
+		int nextSpdxElementNum = this.nextElementRef.getAndIncrement();
 		return formSpdxElementRef(nextSpdxElementNum);
 	}
 
 	public static String formSpdxElementRef(int refNum) {
 		return SPDX_ELEMENT_REF_PRENUM + String.valueOf(refNum);
-	}
-	
-	/**
-	 * @return
-	 */
-	synchronized int getAndIncrementNextElementRef() {
-		int retval = this.nextElementRef;
-		this.nextElementRef++;
-		return retval;
 	}
 
 	/**
@@ -1799,8 +1785,8 @@ public class SPDXDocument implements SpdxRdfConstants, IModelContainer {
 		// add the version
 		this.setSpdxVersion(spdxVersion);
 		// reset the next license number and next spdx element num
-		this.nextElementRef = 1;
-		this.nextLicenseRef = 1;
+		this.nextElementRef.set(1);
+		this.nextLicenseRef.set(1);
 		// add the default data license
 		if (!spdxVersion.equals(POINT_EIGHT_SPDX_VERSION) && !spdxVersion.equals(POINT_NINE_SPDX_VERSION)) { // added as a mandatory field in 1.0
 			try {

--- a/src/org/spdx/rdfparser/SpdxDocumentContainer.java
+++ b/src/org/spdx/rdfparser/SpdxDocumentContainer.java
@@ -19,12 +19,12 @@ package org.spdx.rdfparser;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.license.ExtractedLicenseInfo;
 import org.spdx.rdfparser.license.LicenseInfoFactory;
-import org.spdx.rdfparser.license.SpdxListedLicense;
 import org.spdx.rdfparser.model.ExternalDocumentRef;
 import org.spdx.rdfparser.model.RdfModelObject;
 import org.spdx.rdfparser.model.Relationship;
@@ -111,7 +111,7 @@ public class SpdxDocumentContainer implements IModelContainer, SpdxRdfConstants 
 	/**
 	 * Keeps track of the next SPDX element reference
 	 */
-	private int nextElementRef = 0;
+	private AtomicInteger nextElementRef = new AtomicInteger(0);
 	
 	/**
 	 * Construct an SpdxDocumentContainer from an existing model which
@@ -197,7 +197,7 @@ public class SpdxDocumentContainer implements IModelContainer, SpdxRdfConstants 
 		model.createResource(this.documentNamespace + SPDX_DOCUMENT_ID, spdxAnalysisType);
 		this.addSpdxElementRef(SPDX_DOCUMENT_ID);
 		// reset the next license number and next spdx element num
-		this.nextElementRef = 1;
+		this.nextElementRef.set(1);
 		this.nextLicenseRef = 1;
 		this.documentNode = getSpdxDocNode();
 		this.spdxDocument = new SpdxDocument(this, this.documentNode);
@@ -305,7 +305,7 @@ public class SpdxDocumentContainer implements IModelContainer, SpdxRdfConstants 
 			}
 		}
 		
-		this.nextElementRef = highestElementRef + 1;
+		this.nextElementRef.set(highestElementRef + 1);
 	}
 
 	/**
@@ -399,10 +399,8 @@ public class SpdxDocumentContainer implements IModelContainer, SpdxRdfConstants 
 	/**
 	 * @return
 	 */
-	synchronized int getAndIncrementNextElementRef() {
-		int retval = this.nextElementRef;
-		this.nextElementRef++;
-		return retval;
+	private int getAndIncrementNextElementRef() {
+		return this.nextElementRef.getAndIncrement();
 	}
 	
 	/* (non-Javadoc)


### PR DESCRIPTION
Some attempts were made to synchronize access to indexing variables, but were incomplete - using the Java "Atomic*" APIs results in consistent multi-threading protection for these variables

My contributions are licensed under the Apache 2.0 License as required for contributions to this project