### PR TITLE
Fix Potential Multi-thread issues with DateFormat use

### DIFF
--- a/src/org/spdx/spdxspreadsheet/LicenseSheet.java
+++ b/src/org/spdx/spdxspreadsheet/LicenseSheet.java
@@ -59,7 +59,6 @@ public class LicenseSheet extends AbstractSheet {
 	static final int COL_TEMPLATE = COL_STANDARD_LICENSE_HEADER + 1;
 	static final int COL_VERSION = COL_TEMPLATE + 1;
 	static final int COL_RELEASE_DATE = COL_VERSION + 1;
-	static final SimpleDateFormat dateFormat = new SimpleDateFormat("MMM dd, yyyy");
 
 	static final boolean[] REQUIRED = new boolean[] {true, true, false, false,
 		false, false, true, false, false, false};
@@ -91,6 +90,7 @@ public class LicenseSheet extends AbstractSheet {
 				if (releaseDateCell.getCellType() == Cell.CELL_TYPE_STRING) {
 					this.releaseDate = releaseDateCell.getStringCellValue();
 				} else if (releaseDateCell.getCellType() == Cell.CELL_TYPE_NUMERIC) {
+				    SimpleDateFormat dateFormat = new SimpleDateFormat("MMM dd, yyyy");
 					this.releaseDate = dateFormat.format(releaseDateCell.getDateCellValue());
 				}
 			}

--- a/src/org/spdx/tools/SpreadsheetToRDF.java
+++ b/src/org/spdx/tools/SpreadsheetToRDF.java
@@ -69,7 +69,13 @@ public class SpreadsheetToRDF {
 	static final Logger logger = Logger.getLogger(SpreadsheetToRDF.class.getName());
 	static final int MIN_ARGS = 2;
 	static final int MAX_ARGS = 2;
-	static DateFormat format = new SimpleDateFormat(SpdxRdfConstants.SPDX_DATE_FORMAT);
+	
+	private static final ThreadLocal<DateFormat> format = new ThreadLocal<DateFormat>(){
+	    @Override
+	    protected DateFormat initialValue() {
+	        return new SimpleDateFormat(SpdxRdfConstants.SPDX_DATE_FORMAT);
+	    }
+	  };
 	
 	/**
 	 * @param args
@@ -228,7 +234,7 @@ public class SpreadsheetToRDF {
 		int firstRow = reviewersSheet.getFirstDataRow();
 		SPDXReview[] reviewers = new SPDXReview[numReviewers];
 		for (int i = 0; i < reviewers.length; i++) {
-			reviewers[i] = new SPDXReview(reviewersSheet.getReviewer(firstRow+i), format.format(reviewersSheet.getReviewerTimestamp(firstRow+i)),
+			reviewers[i] = new SPDXReview(reviewersSheet.getReviewer(firstRow+i), format.get().format(reviewersSheet.getReviewerTimestamp(firstRow+i)),
 					reviewersSheet.getReviewerComment(firstRow + i));
 		}
 		analysis.setReviewers(reviewers);
@@ -285,7 +291,7 @@ public class SpreadsheetToRDF {
 
 	private static void copyOrigins(DocumentInfoSheet originsSheet, SpdxDocument analysis) throws InvalidSPDXAnalysisException, SpreadsheetException {
 		Date createdDate = originsSheet.getCreated();
-		String created  = format.format(createdDate);
+		String created  = format.get().format(createdDate);
 		String[] createdBys = originsSheet.getCreatedBy();
 		String creatorComment = originsSheet.getAuthorComments();
 		String licenseListVersion = originsSheet.getLicenseListVersion();


### PR DESCRIPTION
DateFormat, per its Javadoc, is not safe for use in a situation where multiple threads could access it at once. Declaring it in a static context presents this possibility - switching to either a non-static variable or a thread local variable removes this problem.

My contributions are licensed under the Apache 2.0 License as required for contributions to this project