### PR TITLE
Remove potential NPE in FileContext class

### DIFF
--- a/src/org/spdx/html/FileContext.java
+++ b/src/org/spdx/html/FileContext.java
@@ -66,7 +66,7 @@ public class FileContext {
 	}
 	
 	public String spdxId() {
-		if (spdxFile == null && error != null) {
+		if (spdxFile == null) {
 			return "Error getting SPDX file information: "+ (error != null ? error.getMessage() : "null");
 		}
 		return spdxFile.getId();


### PR DESCRIPTION
Remove a potential null dereference from the FileContext class, which would occur if the check was not entered due to the error variable not being set.

My contributions are licensed under the Apache 2.0 License as required for contributions to this project