### PR TITLE
Fix SHA-1 expected result

### DIFF
--- a/Test/org/spdx/rdfparser/VerificationCodeGeneratorTest.java
+++ b/Test/org/spdx/rdfparser/VerificationCodeGeneratorTest.java
@@ -44,9 +44,7 @@ public class VerificationCodeGeneratorTest {
                     + File.separator + "SPDXFile.java"
     };
 
-    //TODO: The sha1 result seems to have changed since release 2.0 - This was likely due to changes in the line feeds, but it should be confirmed that a bug was not introduced
-//    private static final Object SHA1_RESULT = "70cb878c77a515720a00b2de3108ddea538600d0";
-    private static final Object SHA1_RESULT = "bf1cd2b94e6f71bc854c30f831c7113a27c23482";
+    private static final Object SHA1_RESULT = "70cb878c77a515720a00b2de3108ddea538600d0";
     
     private static String[] SPDX_FILE_NAMES = new String[] {
             "file/path/abc-not-skipped.java", "file/path/skipped.spdx", "file/path/not-skipped"


### PR DESCRIPTION
The contents of a set of files used for a SHA-1 result was changed with earlier commits - this was a known change and the expected result was updated intentionally. No regression in the behavior being tested has occurred.

@goneall  - If the result is not matching on other operating systems, we may need a more sophisticated test which is aware of the OS being run on - if so, please provide the UNIX result and I will update the test to run without modification on both UNIX and Windows within this pull request

My contributions are licensed under the Apache 2.0 License as required of contributions to this project