### PR TITLE
Remove useless return assignment

### DIFF
--- a/src/org/spdx/merge/SpdxLicenseMapper.java
+++ b/src/org/spdx/merge/SpdxLicenseMapper.java
@@ -170,17 +170,16 @@ public class SpdxLicenseMapper {
 			for(int i = 0; i < members.length; i++){
 				mappedMembers[i] = mapLicenseInfo(spdxDoc, members[i]);
 			}
-			return new ConjunctiveLicenseSet(mappedMembers);
-		}
-		else if(license instanceof DisjunctiveLicenseSet){
+			license = new ConjunctiveLicenseSet(mappedMembers);
+		}else if(license instanceof DisjunctiveLicenseSet){
 			AnyLicenseInfo[] members = ((DisjunctiveLicenseSet) license).getMembers();
 			AnyLicenseInfo[] mappedMembers = new AnyLicenseInfo[members.length];
 			for(int q = 0; q < members.length; q++ ){
 				mappedMembers[q] = mapLicenseInfo(spdxDoc, members[q]);
 			}
-			return new DisjunctiveLicenseSet(mappedMembers);
+			license = new DisjunctiveLicenseSet(mappedMembers);
 		}else if(license instanceof ExtractedLicenseInfo){
-			return license = mapNonStdLicInMap(spdxDoc,license);
+			license = mapNonStdLicInMap(spdxDoc,license);
 		}
 		return license;	
 	}


### PR DESCRIPTION
Unnecessary assignment in a return statement. In addition, I cleaned up the assignment/return flow to have a single return location, which is generally considered better practice.

My contributions are licensed under the Apache 2.0 License as required for contributions to this project