### PR TITLE
Use result of String.trim()

### DIFF
--- a/src/org/spdx/tag/BuildDocument.java
+++ b/src/org/spdx/tag/BuildDocument.java
@@ -861,7 +861,7 @@ public class BuildDocument implements TagValueBehavior, Serializable {
     }
 
     private static String trim(String value) {
-        value.trim();
+        value = value.trim();
         value = value.replaceAll("<text>", "").replaceAll("</text>", "");
         return value;
     }

--- a/src/org/spdx/tag/BuildLegacyDocument.java
+++ b/src/org/spdx/tag/BuildLegacyDocument.java
@@ -366,7 +366,7 @@ public class BuildLegacyDocument implements TagValueBehavior, Serializable {
 	}
 
 	private static String trim(String value) {
-		value.trim();
+	    value = value.trim();
 		value = value.replaceAll("<text>", "").replaceAll("</text>", "")
 				.replaceAll("SHA1: ", "");
 		return value;

--- a/src/org/spdx/tag/CommonCode.java
+++ b/src/org/spdx/tag/CommonCode.java
@@ -77,7 +77,6 @@ public class CommonCode {
 	 * @param constants
 	 * @throws InvalidSPDXAnalysisException
 	 */
-	@SuppressWarnings("deprecation")
 	public static void printDoc(SpdxDocument doc, PrintWriter out,
 			Properties constants) throws InvalidSPDXAnalysisException {
 		if (doc == null) {
@@ -202,9 +201,10 @@ public class CommonCode {
 			}
 		}
 		// Reviewers
-		if (doc.getReviewers() != null && doc.getReviewers().length > 0) {
+		SPDXReview[] reviewedBy = doc.getReviewers();
+		
+		if (reviewedBy != null && reviewedBy.length > 0) {
 			println(out, constants.getProperty("REVIEW_INFO_HEADER"));
-			SPDXReview[] reviewedBy = doc.getReviewers();
 			for (int i = 0; i < reviewedBy.length; i++) {
 				println(out, constants.getProperty("PROP_REVIEW_REVIEWER")
 						+ reviewedBy[i].getReviewer());
@@ -524,7 +524,6 @@ public class CommonCode {
 	/**
 	 * @param file
 	 */
-	@SuppressWarnings("deprecation")
 	private static void printFile(SpdxFile file, PrintWriter out,
 			Properties constants) {
 		printElementProperties(file, out, constants, "PROP_FILE_NAME", 
@@ -590,10 +589,10 @@ public class CommonCode {
 			}
 		}
 		// file dependencies
-		if (file.getFileDependencies() != null && file.getFileDependencies().length > 0) {
-			for (int i = 0; i < file.getFileDependencies().length; i++) {
-				println(out, constants.getProperty("PROP_FILE_DEPENDENCY") + 
-						file.getFileDependencies()[i].getName());
+		SpdxFile[] fileDependencies = file.getFileDependencies();
+		if (fileDependencies != null && fileDependencies.length > 0) {
+			for (SpdxFile fileDepdency : fileDependencies) {
+				println(out, constants.getProperty("PROP_FILE_DEPENDENCY") + fileDepdency.getName());
 			}
 		}
 		printElementAnnotationsRelationships(file, out, constants, "PROP_FILE_NAME", 

--- a/src/org/spdx/tools/SpreadsheetToRDF.java
+++ b/src/org/spdx/tools/SpreadsheetToRDF.java
@@ -321,7 +321,7 @@ public class SpreadsheetToRDF {
 		analysis.setCreationInfo(creator);
 		String docComment = originsSheet.getDocumentComment();
 		if (docComment != null) {
-			docComment.trim();
+		    docComment = docComment.trim();
 			if (!docComment.isEmpty()) {
 				analysis.setComment(docComment);
 			}


### PR DESCRIPTION
There are several places where String.trim() is used, but the result is not stored - this is a common mistake where many developers do not realize the trim() function does not change the variable it is called on, but returns a new variable which has been trimmed.

In addition, I reduced the number of calls to a couple of deprecated methods.

My contributions are licensed under the Apache 2.0 License as required for contributions to this project