### PR TITLE
Prevent an NPE if the doc reference is not populated

### DIFF
--- a/src/org/spdx/tools/RdfToSpreadsheet.java
+++ b/src/org/spdx/tools/RdfToSpreadsheet.java
@@ -98,35 +98,37 @@ public class RdfToSpreadsheet {
 		} catch (IOException e) {
 			System.out.print("Unable to open file :"+args[0]+", "+e.getMessage());
 		}
-		if(doc != null){
-		SPDXSpreadsheet ss = null;
-		try {
-			ss = new SPDXSpreadsheet(spdxSpreadsheetFile, true, false);
-			copyRdfXmlToSpreadsheet(doc, ss);
-			List<String> verify = doc.verify();
-			if (verify != null && verify.size() > 0) {
-				System.out.println("Warning: The following verifications failed for the resultant SPDX RDF file:");
-				for (int i = 0; i < verify.size(); i++) {
-					System.out.println("\t"+verify.get(i));
-				}
-			}
-		} catch (SpreadsheetException e) {
-			System.out.println("Error opening or writing to spreadsheet: "+e.getMessage());
-		} catch (InvalidSPDXAnalysisException e) {
-			System.out.println("Error translating the RDF file: "+e.getMessage());
-		} catch (Exception ex) {
-			System.out.println("Unexpected error translating the RDF to spreadsheet: "+ex.getMessage());
-		} finally {
-			if (ss != null) {
-				try {
-					ss.close();
-				} catch (SpreadsheetException e) {
-					System.out.println("Error closing spreadsheet: "+e.getMessage());
-				}
-			}
-		}
-		}
-	}
+        if (doc != null) {
+            SPDXSpreadsheet ss = null;
+            try {
+                ss = new SPDXSpreadsheet(spdxSpreadsheetFile, true, false);
+                copyRdfXmlToSpreadsheet(doc, ss);
+                List<String> verify = doc.verify();
+                if (verify != null && verify.size() > 0) {
+                    System.out.println("Warning: The following verifications failed for the resultant SPDX RDF file:");
+                    for (int i = 0; i < verify.size(); i++) {
+                        System.out.println("\t" + verify.get(i));
+                    }
+                }
+            } catch (SpreadsheetException e) {
+                System.out.println("Error opening or writing to spreadsheet: " + e.getMessage());
+            } catch (InvalidSPDXAnalysisException e) {
+                System.out.println("Error translating the RDF file: " + e.getMessage());
+            } catch (Exception ex) {
+                System.out.println("Unexpected error translating the RDF to spreadsheet: " + ex.getMessage());
+            } finally {
+                if (ss != null) {
+                    try {
+                        ss.close();
+                    } catch (SpreadsheetException e) {
+                        System.out.println("Error closing spreadsheet: " + e.getMessage());
+                    }
+                }
+            }
+        }else{
+            System.out.println("Error creating SPDX docuement reference, null reference returned");
+        }
+    }
 
 	@SuppressWarnings("deprecation")
 	public static void copyRdfXmlToSpreadsheet(SpdxDocument doc,

--- a/src/org/spdx/tools/RdfToSpreadsheet.java
+++ b/src/org/spdx/tools/RdfToSpreadsheet.java
@@ -98,6 +98,7 @@ public class RdfToSpreadsheet {
 		} catch (IOException e) {
 			System.out.print("Unable to open file :"+args[0]+", "+e.getMessage());
 		}
+		if(doc != null){
 		SPDXSpreadsheet ss = null;
 		try {
 			ss = new SPDXSpreadsheet(spdxSpreadsheetFile, true, false);
@@ -123,6 +124,7 @@ public class RdfToSpreadsheet {
 					System.out.println("Error closing spreadsheet: "+e.getMessage());
 				}
 			}
+		}
 		}
 	}
 


### PR DESCRIPTION
There is a location where is is possible a document reference will be null - I have adjusted the code following to check for this condition and not fail with a NPE if this occurrs.

My contributions are licensed under the Apache 2.0 License