### PR TITLE
Fix an NPE when adding creators

### DIFF
--- a/src/org/spdx/rdfparser/model/SpdxDocument.java
+++ b/src/org/spdx/rdfparser/model/SpdxDocument.java
@@ -71,7 +71,7 @@ public class SpdxDocument extends SpdxElement {
 		if (this.getCreationInfo() == null){
 			String licenseListVersion = ListedLicenses.getListedLicenses().getLicenseListVersion();
 			String creationDate = DateFormatUtils.format(Calendar.getInstance(), SpdxRdfConstants.SPDX_DATE_FORMAT);
-			SPDXCreatorInformation creationInfo = new SPDXCreatorInformation(null, creationDate, null, licenseListVersion);
+			SPDXCreatorInformation creationInfo = new SPDXCreatorInformation(new String[] {  }, creationDate, null, licenseListVersion);
 			setCreationInfo(creationInfo);
 		}
 		else if (StringUtils.isBlank(this.getCreationInfo().getLicenseListVersion())){


### PR DESCRIPTION
Do not initialize the array of creators to "null" but to an empty array to
avoid an NPE when adding creators later. It is in line with other calls
to "new SPDXCreatorInformation()" to pass "new String[] {  }" instead of
"null".

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>