### PR TITLE
Add a .mailmap file to uniquely identify authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Gang Ling <linggang7@gmail.com>
+Gary O'Neall <gary@sourceauditor.com>
+Peter Williams <peter.williams@openlogic.com> <pezra@barelyenough.org>
+Roger Meier <r.meier@siemens.com> <roger@bufferoverflow.ch>
+Ryan O'Meara <romeara@blackducksoftware.com>


### PR DESCRIPTION
Some authors use different user names and / or email addresses for their
commits. Map these to a single unique identify. For details see "Mapping
authors" at http://git-scm.com/docs/git-shortlog.html.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>