### PR TITLE
LicenseExpressionParser: Allow "+" as part of license-refs

### DIFF
--- a/src/org/spdx/rdfparser/license/LicenseExpressionParser.java
+++ b/src/org/spdx/rdfparser/license/LicenseExpressionParser.java
@@ -101,7 +101,7 @@ public class LicenseExpressionParser {
 		} else if (preToken.endsWith(")")) {
 			processPreToken(preToken.substring(0, preToken.length()-1), tokenList);
 			tokenList.add(")");
-		} else if (preToken.endsWith("+")) {
+		} else if (preToken.endsWith("+") && !(preToken.startsWith(SpdxRdfConstants.EXTERNAL_DOC_REF_PRENUM) || preToken.startsWith(SpdxRdfConstants.NON_STD_LICENSE_ID_PRENUM))) {
 			processPreToken(preToken.substring(0, preToken.length()-1), tokenList);
 			tokenList.add("+");
 		} else {


### PR DESCRIPTION
license-refs as defined in Appendix IV of the SPDX 2.0 specification
should be allowed to contain "+", e.g. to write "LicenseRef-LGPL-3.0+".
Currently, LicenseExpressionParser interprets "+" in license-refs as
Operator.OR_LATER even if they are no compound-expression. Fix this by
checking the compound-expression for a license-ref and do not take "+" as
a token in that case.