### PR TITLE
Add parse error details to exception message

### DIFF
--- a/src/org/spdx/rdfparser/SpdxDocumentContainer.java
+++ b/src/org/spdx/rdfparser/SpdxDocumentContainer.java
@@ -559,7 +559,7 @@ public class SpdxDocumentContainer implements IModelContainer, SpdxRdfConstants 
 		
 		for (int i = 0; i < extractedAnyLicenseInfo.length; i++) {
 			if (!(extractedAnyLicenseInfo[i] instanceof ExtractedLicenseInfo)) {
-				throw new InvalidSPDXAnalysisException("Invalid type for extracted license infos");
+				throw new InvalidSPDXAnalysisException("Invalid type for extracted license infos: " + extractedAnyLicenseInfo[i]);
 			}
 			ExtractedLicenseInfo lic = (ExtractedLicenseInfo)extractedAnyLicenseInfo[i];
 			this.licenseIdToExtractedLicense.put(lic.getLicenseId(), lic);

--- a/src/org/spdx/tools/CompareSpdxDocs.java
+++ b/src/org/spdx/tools/CompareSpdxDocs.java
@@ -1138,6 +1138,7 @@ public class CompareSpdxDocs {
 		}
 
 		SpdxDocument retval = null;
+		String errorDetails = "(no error details available)";
 		try {
 			// Try to open the file as a tag/value file first.
 			retval = convertTagValueToRdf(spdxDocFile, warnings);
@@ -1151,15 +1152,18 @@ public class CompareSpdxDocs {
 				retval = SPDXDocumentFactory.createSpdxDocument(spdxDocFileName);
 				logger.info("Document identified as SPDX RDF/XML.");
 			} catch (IOException e) {
+				errorDetails = e.getMessage();
 				// Ignore - unrecognized files are handled below.
 			} catch (InvalidSPDXAnalysisException e) {
+				errorDetails = e.getMessage();
 				// Ignore - unrecognized files are handled below.
 			} catch (Exception e) {
+				errorDetails = e.getMessage();
 				// Ignore - unrecognized files are handled below.
 			}
 		}
 		if (retval == null) {
-			throw(new SpdxCompareException("File "+spdxDocFileName+" is not a recognized RDF/XML or tag/value format"));
+			throw(new SpdxCompareException("File "+spdxDocFileName+" is not a recognized RDF/XML or tag/value format: " + errorDetails));
 		}
 		return retval;
 	}


### PR DESCRIPTION
This PR changes this error message:
```
Unable to parse the file: File testfile.rdf is not a recognized RDF/XML or tag/value format
```

to this:
```
Unable to parse the file: File testfile.rdf is not a recognized RDF/XML or tag/value format: Invalid type for extracted license infos: BSD-3-Clause
```

My contributions are done under the terms of the Apache License, version 2.0.