### PR TITLE
Missing Documentation Fails Maven Build Against Java 8 Environment #12

### DIFF
--- a/Test/org/spdx/licenseTemplate/TestHtmlTemplateOutputHandler.java
+++ b/Test/org/spdx/licenseTemplate/TestHtmlTemplateOutputHandler.java
@@ -216,7 +216,7 @@ public class TestHtmlTemplateOutputHandler {
 	@Test
 	public void testFormatEndOptionalHTML() {
 		String escapedEndRuleText = "</div>\n";
-		assertEquals(escapedEndRuleText, HtmlTemplateOutputHandler.formatEndOptionalHTML());
+		assertEquals(escapedEndRuleText, HtmlTemplateOutputHandler.formatEndOptionalHTML(false));
 
 	}
 

--- a/src/org/spdx/licenseTemplate/HtmlTemplateOutputHandler.java
+++ b/src/org/spdx/licenseTemplate/HtmlTemplateOutputHandler.java
@@ -41,8 +41,7 @@ public class HtmlTemplateOutputHandler implements ILicenseTemplateOutputHandler 
 	 */
 	@Override
 	public void optionalText(String text) {
-		htmlString.append((SpdxLicenseTemplateHelper.escapeHTML(text, this.movingParagraph)));
-		this.movingParagraph = false;
+		htmlString.append((SpdxLicenseTemplateHelper.escapeHTML(text, false)));
 	}
 
 	/* (non-Javadoc)
@@ -189,8 +188,12 @@ public class HtmlTemplateOutputHandler implements ILicenseTemplateOutputHandler 
 		return sb.toString();
 	}
 
-	public static String formatEndOptionalHTML() {
-		return "</div>\n";
+	public static String formatEndOptionalHTML(boolean inParagraph) {
+		if (inParagraph) {
+			return "</div>\n</p>\n";
+		} else {
+			return "</div>\n";
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -198,7 +201,8 @@ public class HtmlTemplateOutputHandler implements ILicenseTemplateOutputHandler 
 	 */
 	@Override
 	public void endOptional(LicenseTemplateRule rule) {
-		this.htmlString.append(formatEndOptionalHTML());
+		this.htmlString.append(formatEndOptionalHTML(this.movingParagraph));
+		this.movingParagraph = false;
 		inOptional = false;
 	}
 }


### PR DESCRIPTION
This fix disable Java-doc strict checking during compilation in Java 8. Could be consider a temporary fix for the issue until the errors are resolved.