### PR TITLE
Handle two continuous START TEXT TAG by throwing Error

### DIFF
--- a/Test/org/spdx/tag/TestBuildDocument.java
+++ b/Test/org/spdx/tag/TestBuildDocument.java
@@ -318,7 +318,7 @@ public class TestBuildDocument {
 	@Test
 	public void testBuildSimpleDocument() throws Exception {
 		InputStream bais = new ByteArrayInputStream(SIMPLE_TAGDOCUMENT.getBytes());
-		HandBuiltParser parser = new HandBuiltParser(bais);
+		HandBuiltParser parser = new HandBuiltParser((NoCommentInputStream)bais);
 		List<String> warnings = Lists.newArrayList();
 		Properties constants = CommonCode.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
 		SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];
@@ -330,7 +330,7 @@ public class TestBuildDocument {
 	
 	@Test public void testExternalRefs() throws Exception {
 		InputStream bais = new ByteArrayInputStream(SIMPLE_TAGDOCUMENT.getBytes());
-		HandBuiltParser parser = new HandBuiltParser(bais);
+		HandBuiltParser parser = new HandBuiltParser((NoCommentInputStream)bais);
 		List<String> warnings = Lists.newArrayList();
 		Properties constants = CommonCode.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
 		SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];
@@ -353,7 +353,7 @@ public class TestBuildDocument {
 	@Test 
 	public void testNoFilesAnalyzedFiles()  throws Exception {
 		InputStream bais = new ByteArrayInputStream(TAGDOCUMENT_NO_FILES.getBytes());
-		HandBuiltParser parser = new HandBuiltParser(bais);
+		HandBuiltParser parser = new HandBuiltParser((NoCommentInputStream)bais);
 		List<String> warnings = Lists.newArrayList();
 		Properties constants = CommonCode.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
 		SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];
@@ -369,7 +369,7 @@ public class TestBuildDocument {
 	@Test 
 	public void testFile()  throws Exception {
 		InputStream bais = new ByteArrayInputStream(SIMPLE_TAGDOCUMENT.getBytes());
-		HandBuiltParser parser = new HandBuiltParser(bais);
+		HandBuiltParser parser = new HandBuiltParser((NoCommentInputStream)bais);
 		List<String> warnings = Lists.newArrayList();
 		Properties constants = CommonCode.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
 		SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];
@@ -391,7 +391,7 @@ public class TestBuildDocument {
 	public void testSnippet()  throws Exception {
 		
 		InputStream bais = new ByteArrayInputStream(SIMPLE_TAGDOCUMENT.getBytes());
-		HandBuiltParser parser = new HandBuiltParser(bais);
+		HandBuiltParser parser = new HandBuiltParser((NoCommentInputStream)bais);
 		List<String> warnings = Lists.newArrayList();
 		Properties constants = CommonCode.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
 		SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];

--- a/src/org/spdx/tag/HandBuiltParser.java
+++ b/src/org/spdx/tag/HandBuiltParser.java
@@ -51,8 +51,8 @@ public class HandBuiltParser {
 		this.textInput = textInput;
 	}
 
-	public HandBuiltParser(InputStream bais) {
-		this.textInput = textInput;
+	public HandBuiltParser(InputStream textInput) {
+		this.textInput = (NoCommentInputStream) textInput;
 	}
 
 	/**

--- a/src/org/spdx/tag/HandBuiltParser.java
+++ b/src/org/spdx/tag/HandBuiltParser.java
@@ -40,14 +40,14 @@ public class HandBuiltParser {
 	private static final String START_TEXT = "<text>";
 	Pattern tagPattern = Pattern.compile("^\\w+:");
 	private TagValueBehavior buildDocument;
-	private InputStream textInput;
+	private NoCommentInputStream textInput;
 
 	/**
 	 * Creates a parser for an Input stream.
 	 * The input stream must not use any comments.
 	 * @param textInput
 	 */
-	public HandBuiltParser(InputStream textInput) {
+	public HandBuiltParser(NoCommentInputStream textInput) {
 		this.textInput = textInput;
 	}
 

--- a/src/org/spdx/tag/HandBuiltParser.java
+++ b/src/org/spdx/tag/HandBuiltParser.java
@@ -51,10 +51,6 @@ public class HandBuiltParser {
 		this.textInput = textInput;
 	}
 
-	public HandBuiltParser(InputStream textInput) {
-		this.textInput = (NoCommentInputStream) textInput;
-	}
-
 	/**
 	 * @param buildDocument
 	 */

--- a/src/org/spdx/tag/HandBuiltParser.java
+++ b/src/org/spdx/tag/HandBuiltParser.java
@@ -72,6 +72,9 @@ public class HandBuiltParser {
 			String nextLine = br.readLine();
 			while (nextLine != null) {
 				if (inTextBlock) {
+					if (nextLine.indexOf(START_TEXT)>0){
+						break;
+					}
 					int endText = nextLine.indexOf(END_TEXT);
 					if (endText >= 0) {
 						value = value + "\n" + nextLine.substring(0, endText).trim();

--- a/src/org/spdx/tag/HandBuiltParser.java
+++ b/src/org/spdx/tag/HandBuiltParser.java
@@ -51,6 +51,10 @@ public class HandBuiltParser {
 		this.textInput = textInput;
 	}
 
+	public HandBuiltParser(InputStream bais) {
+		this.textInput = textInput;
+	}
+
 	/**
 	 * @param buildDocument
 	 */
@@ -73,7 +77,8 @@ public class HandBuiltParser {
 			while (nextLine != null) {
 				if (inTextBlock) {
 					if (nextLine.indexOf(START_TEXT)>0){
-						break;
+						throw(new RecognitionException("Found a text block inside another text block at line " + 
+									(textInput.getLineNo(nextLine)+1) + ".  Expecting "+END_TEXT));
 					}
 					int endText = nextLine.indexOf(END_TEXT);
 					if (endText >= 0) {

--- a/src/org/spdx/tag/NoCommentInputStream.java
+++ b/src/org/spdx/tag/NoCommentInputStream.java
@@ -20,6 +20,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 
 import org.apache.log4j.Logger;
 
@@ -44,7 +45,7 @@ public class NoCommentInputStream extends InputStream {
 	private int bytesIndex;
 	private byte[] currentBytes;
 	boolean inText = false;
-	
+	private ArrayList<String> FileLines = new ArrayList<String>();
 
 	/**
 	 * @param in Input stream containing the commented data
@@ -67,6 +68,7 @@ public class NoCommentInputStream extends InputStream {
 			if (currentLine == null) {
 				return;
 			}
+			FileLines.add(currentLine);
 		} while (!inText && (currentLine.length() == 0 || currentLine.charAt(0) == COMMENT_CHAR));
 
 		if (inText) {
@@ -132,6 +134,14 @@ public class NoCommentInputStream extends InputStream {
 				logger.error("IO Error closing input stream: "+e.getMessage());
 			}
 		}
+	}
+	
+	/**
+	 * Searches for the string in the file stored in FileLine and returns the line no. if found.
+	 * @param string to be searched in the file
+	 */
+	public int getLineNo(String searchline){
+		return FileLines.indexOf(searchline);
 	}
 	
 }

--- a/src/org/spdx/tag/NoCommentInputStream.java
+++ b/src/org/spdx/tag/NoCommentInputStream.java
@@ -74,7 +74,7 @@ public class NoCommentInputStream extends InputStream {
 				inText = false;
 			}
 		} else {
-			if (currentLine.contains(START_TEXT_TAG)) {
+			if (currentLine.contains(START_TEXT_TAG) && !currentLine.contains(END_TEXT_TAG)) {
 				inText = true;
 			}
 		}

--- a/src/org/spdx/tools/TagToRDF.java
+++ b/src/org/spdx/tools/TagToRDF.java
@@ -206,7 +206,7 @@ public class TagToRDF {
 		NoCommentInputStream nci = new NoCommentInputStream(spdxTagFile);
 //		TagValueLexer lexer = new TagValueLexer(new DataInputStream(nci));
 //		TagValueParser parser = new TagValueParser(lexer);
-		HandBuiltParser parser = new HandBuiltParser(new DataInputStream(nci));
+		HandBuiltParser parser = new HandBuiltParser(nci);
 		SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];
 		parser.setBehavior(new BuildDocument(result, constants, warnings));
 		parser.data();

--- a/src/org/spdx/tools/TagToSpreadsheet.java
+++ b/src/org/spdx/tools/TagToSpreadsheet.java
@@ -82,7 +82,7 @@ public class TagToSpreadsheet {
 			// read the tag-value constants from a file
 			Properties constants = CommonCode.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
 			NoCommentInputStream nci = new NoCommentInputStream(spdxTagFile);
-			HandBuiltParser parser = new HandBuiltParser(new DataInputStream(nci));
+			HandBuiltParser parser = new HandBuiltParser(nci);
 			List<String> warnings = new ArrayList<String>();
 			parser.setBehavior(new BuildDocument(result, constants, warnings));
 			parser.data();


### PR DESCRIPTION
* HandBuiltParser is also not giving error when two START_TEXT are encountered one after the other without the END_TEXT.
* It ignores the second START_TEXT and take the END_TEXT for the first START_TEXT

Signed-off-by: rtgdk <rohit.lodhartg@gmail.com>