### PR TITLE
Showing line no. of error in tag value by throwing expections.

### DIFF
--- a/src/org/spdx/tag/HandBuiltParser.java
+++ b/src/org/spdx/tag/HandBuiltParser.java
@@ -111,7 +111,7 @@ public class HandBuiltParser {
 				nextLine = textInput.readLine();
 			}
 			if (inTextBlock) {
-				throw(new RecognitionException("Unterminated text block.  Expecting "+END_TEXT));
+				throw(new RecognitionException("Unterminated text block at line " + (textInput.getCurrentLineNo()) + " Expecting "+END_TEXT ));
 			}
 			this.buildDocument.exit();
 		} finally {

--- a/src/org/spdx/tools/TagToRDF.java
+++ b/src/org/spdx/tools/TagToRDF.java
@@ -206,14 +206,19 @@ public class TagToRDF {
 		NoCommentInputStream nci = new NoCommentInputStream(spdxTagFile);
 //		TagValueLexer lexer = new TagValueLexer(new DataInputStream(nci));
 //		TagValueParser parser = new TagValueParser(lexer);
-		HandBuiltParser parser = new HandBuiltParser(nci);
-		SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];
-		parser.setBehavior(new BuildDocument(result, constants, warnings));
-		parser.data();
-		if (result[0] == null) {
-			throw(new RuntimeException("Unexpected error parsing SPDX tag document - the result is null."));
+		try{
+			HandBuiltParser parser = new HandBuiltParser(nci);
+			SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];
+			parser.setBehavior(new BuildDocument(result, constants, warnings));
+			parser.data();
+			if (result[0] == null) {
+				throw(new RuntimeException("Unexpected error parsing SPDX tag document - the result is null."));
+			}
+			return result[0];
 		}
-		return result[0];
+		catch (RecognitionException e) {
+			throw(new RecognitionException(e.getMessage()));
+		}
 	}
 
 


### PR DESCRIPTION
Added try catch in TagToRDF for returning line no. of error by throwing exceptions when executing HandBuiltParser.
It still shows 2 exceptions when it is an invalid file. One for Tag Value Exception and one for RDF.
So when we pass an invalid file format or an invalid TagValue or invalid RDF file, it will combine 2 exception together. It needs to fixed.