### PR TITLE
Identify Invalid SPDX File format and Invalid Tag Value file as different error.

### DIFF
--- a/src/org/spdx/tag/BuildDocument.java
+++ b/src/org/spdx/tag/BuildDocument.java
@@ -827,13 +827,13 @@ public class BuildDocument implements TagValueBehavior {
 				relationshipType, lineNumber);
 	}
 
-	private void checkAnalysisNull() throws InvalidSpdxTagFileException, InvalidSPDXAnalysisException {
+	private void checkAnalysisNull() throws InvalidSpdxTagFileException, InvalidSPDXAnalysisException,InvalidFileFormatException {
 		if (this.analysis == null) {
 			if (this.specVersion != null && this.specVersion.compareTo("SPDX-2.0") < 0) {
 				result[0] = new SpdxDocumentContainer(generateDocumentNamespace());
 				this.analysis = result[0].getSpdxDocument();
 			} else {
-				throw(new InvalidSpdxTagFileException("The SPDX Document Namespace must be set before other SPDX document properties are set."));
+				throw(new InvalidFileFormatException("The SPDX Document Namespace must be set before other SPDX document properties are set."));
 			}
 		}
 	}
@@ -1366,7 +1366,7 @@ public class BuildDocument implements TagValueBehavior {
 	 * @throws InvalidSpdxTagFileException 
 	 */
 	@SuppressWarnings("deprecation")
-	private void fixFileAndSnippetDependencies() throws InvalidSPDXAnalysisException, InvalidSpdxTagFileException {
+	private void fixFileAndSnippetDependencies() throws InvalidSPDXAnalysisException, InvalidSpdxTagFileException,InvalidFileFormatException {
 		// be prepared - it is complicate to make this efficient
 		// the HashMap fileDependencyMap contains a map from a file name to all SPDX files which
 		// reference that file name as a dependency

--- a/src/org/spdx/tag/InvalidFileFormatException.java
+++ b/src/org/spdx/tag/InvalidFileFormatException.java
@@ -1,0 +1,56 @@
+/**
+ * 
+ */
+package org.spdx.tag;
+
+/**
+ * @author rtgdk
+ *
+ */
+public class InvalidFileFormatException extends Exception {
+
+	/**
+	 * 
+	 */
+	public InvalidFileFormatException() {
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * @param message
+	 */
+	public InvalidFileFormatException(String message) {
+		super(message);
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * @param cause
+	 */
+	public InvalidFileFormatException(Throwable cause) {
+		super(cause);
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * @param message
+	 * @param cause
+	 */
+	public InvalidFileFormatException(String message, Throwable cause) {
+		super(message, cause);
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * @param message
+	 * @param cause
+	 * @param enableSuppression
+	 * @param writableStackTrace
+	 */
+	public InvalidFileFormatException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/src/org/spdx/tag/InvalidFileFormatException.java
+++ b/src/org/spdx/tag/InvalidFileFormatException.java
@@ -1,10 +1,25 @@
 /**
- * 
- */
+ * Copyright (c) 2017 Source Auditor Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+*/
 package org.spdx.tag;
 
 /**
- * @author rtgdk
+ * Exceptions for invalid SPDX file format
+ * 
+ * @author Rohit Lodha
  *
  */
 public class InvalidFileFormatException extends Exception {
@@ -13,7 +28,6 @@ public class InvalidFileFormatException extends Exception {
 	 * 
 	 */
 	public InvalidFileFormatException() {
-		// TODO Auto-generated constructor stub
 	}
 
 	/**
@@ -21,7 +35,6 @@ public class InvalidFileFormatException extends Exception {
 	 */
 	public InvalidFileFormatException(String message) {
 		super(message);
-		// TODO Auto-generated constructor stub
 	}
 
 	/**
@@ -29,7 +42,6 @@ public class InvalidFileFormatException extends Exception {
 	 */
 	public InvalidFileFormatException(Throwable cause) {
 		super(cause);
-		// TODO Auto-generated constructor stub
 	}
 
 	/**
@@ -38,7 +50,6 @@ public class InvalidFileFormatException extends Exception {
 	 */
 	public InvalidFileFormatException(String message, Throwable cause) {
 		super(message, cause);
-		// TODO Auto-generated constructor stub
 	}
 
 	/**
@@ -50,7 +61,6 @@ public class InvalidFileFormatException extends Exception {
 	public InvalidFileFormatException(String message, Throwable cause, boolean enableSuppression,
 			boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
-		// TODO Auto-generated constructor stub
 	}
 
 }

--- a/src/org/spdx/tools/TagToRDF.java
+++ b/src/org/spdx/tools/TagToRDF.java
@@ -34,6 +34,8 @@ import org.spdx.rdfparser.SpdxDocumentContainer;
 import org.spdx.tag.BuildDocument;
 import org.spdx.tag.CommonCode;
 import org.spdx.tag.HandBuiltParser;
+import org.spdx.tag.InvalidFileFormatException;
+import org.spdx.tag.InvalidSpdxTagFileException;
 import org.spdx.tag.NoCommentInputStream;
 
 import antlr.RecognitionException;
@@ -200,7 +202,7 @@ public class TagToRDF {
 	 * @throws Exception
 	 */
 	public static SpdxDocumentContainer convertTagFileToRdf(
-			InputStream spdxTagFile, String outputFormat, List<String> warnings) throws RecognitionException, TokenStreamException, Exception  {
+			InputStream spdxTagFile, String outputFormat, List<String> warnings) throws RecognitionException, TokenStreamException,InvalidSpdxTagFileException,InvalidFileFormatException, Exception  {
 		// read the tag-value constants from a file
 		Properties constants = CommonCode.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
 		NoCommentInputStream nci = new NoCommentInputStream(spdxTagFile);
@@ -215,9 +217,15 @@ public class TagToRDF {
 				throw(new RuntimeException("Unexpected error parsing SPDX tag document - the result is null."));
 			}
 			return result[0];
-		}
-		catch (RecognitionException e) {
-			throw(new RecognitionException(e.getMessage()));
+		} catch (RecognitionException e) {
+			// error in tag value file
+			throw(new InvalidSpdxTagFileException(e.getMessage()));
+		} catch (InvalidFileFormatException e) {
+			// invalid spdx file format
+			throw(new InvalidFileFormatException(e.getMessage()));
+		} catch (Exception e){
+			// If any other exception - assume this is an RDF/XML file.
+			throw(new Exception(e.getMessage()));
 		}
 	}
 


### PR DESCRIPTION
I have added a new Exception InvalidFileFormatException for catching all invalid files which are not tag value or rdf files and thrown the exception where all invalid Files were failing in `BuildDocument.checkAnalysisNull ` .

Also when handling expection I have separated, all the three exception in all the enclosing function -
Invalid file type - `InvalidFileFormatException`,
Invalid Tag Value File - `InvalidSpdxTagFileException`,
Invalid RDF or any other file not caught by the above exception  - `Exception`  ( Default Exception )

When in `CompareSPDXDocs.convertTagValueToRdf` the first two exception are caught and thrown as `SpdxCompareException` which result in terminating the function and show proper error. This way, these two types of file will not be passed as RDF Files in later function.

Only Invalid RDF, Valid RDF or any other file not caught by the first two exception are passed in the second function to check for RDF files.