### PR TITLE
Add separate methods for verifying tag value and rdf file.

### DIFF
--- a/src/org/spdx/tools/CompareSpdxDocs.java
+++ b/src/org/spdx/tools/CompareSpdxDocs.java
@@ -1182,7 +1182,7 @@ public class CompareSpdxDocs {
 	 * @param tagValueFile Input file in tag/value format
 	 * @param tempRdfFile File to output the generated RDF file (must already exist - file is overwritten)
 	 */
-	private static SpdxDocument convertTagValueToRdf(File tagValueFile, List<String> warnings) throws SpdxCompareException,Exception {
+	protected static SpdxDocument convertTagValueToRdf(File tagValueFile, List<String> warnings) throws SpdxCompareException,Exception {
 		FileInputStream in = null;
 		try {
 			in = new FileInputStream(tagValueFile);


### PR DESCRIPTION
`verifyTagFile` for verifying only tag value file and throws exception if found otherwise.
`verifyRDFFile` for verifying only RDF/XML file and throws exception if found otherwise.

This will be useful when checking for file type while conversion from tag to other formats and rdf to other formats on online tool or in comparison tool for rdf files only.

I also changed the access of `convertTagValueToRdf` function from private to protected. I hope it doesn't create any permission error.