### PR TITLE
Update java tools with methods to be called from online tool.

### DIFF
--- a/src/org/spdx/tools/CompareMultpleSpdxDocs.java
+++ b/src/org/spdx/tools/CompareMultpleSpdxDocs.java
@@ -57,11 +57,25 @@ public class CompareMultpleSpdxDocs {
 			usage();
 			System.exit(ERROR_STATUS);
 		}
-		File outputFile = new File(args[0]);
-		if (outputFile.exists()) {
-			System.out.println("Output file "+args[0]+" already exists.");
-			usage();
+		try {
+			onlineFunction(args);
+		} catch (OnlineToolException e){
+			System.out.println(e.getMessage());
 			System.exit(ERROR_STATUS);
+		}
+	}
+	
+	/**
+	 * 
+	 * @param args args[0] is the output Excel file name, all other args are SPDX document file names
+	 * @throws OnlineToolException Exception caught by JPype and displayed to the user
+	 */
+	public static void onlineFunction(String[] args) throws OnlineToolException{
+		// Arguments length( 14>=args length>=3 ) will checked in the Python Code
+		File outputFile = new File(args[0]);
+		// Output File name will be checked in the Python code for no clash, but if still found
+		if (outputFile.exists()) {
+			throw new OnlineToolException("Output file "+args[0]+" already exists. Change the name of the result file.");
 		}
 		SpdxDocument[] compareDocs = new SpdxDocument[args.length-1];
 		String[] docNames = new String[args.length-1];
@@ -80,8 +94,7 @@ public class CompareMultpleSpdxDocs {
 					System.out.println("Warning: "+docNames[i-1]+" contains verification errors.");
 				}
 			} catch (SpdxCompareException e) {
-				System.out.println("Error opening SPDX document "+args[i]+": "+e.getMessage());
-				System.exit(ERROR_STATUS);
+				throw new OnlineToolException("Error opening SPDX document "+args[i]+": "+e.getMessage());
 			}
 		}
 		MultiDocumentSpreadsheet outSheet = null;
@@ -92,68 +105,16 @@ public class CompareMultpleSpdxDocs {
 			comparer.compare(compareDocs);
 			outSheet.importCompareResults(comparer, docNames);
 		} catch (SpreadsheetException e) {
-			System.out.println("Unable to create output spreadsheet: "+e.getMessage());
-			System.exit(ERROR_STATUS);
-		} catch (InvalidSPDXAnalysisException e) {
-			System.out.println("Invalid SPDX analysis: "+e.getMessage());
-			System.exit(ERROR_STATUS);
-		} catch (SpdxCompareException e) {
-			System.out.println("Error comparing SPDX documents: "+e.getMessage());
-			System.exit(ERROR_STATUS);
-		} finally {
-			if (outSheet != null) {
-				try {
-					outSheet.close();
-				} catch (SpreadsheetException e) {
-					System.out.println("Warning - error closing spreadsheet: "+e.getMessage());
-				}
-			}
-		}
-	}
-	
-	/**
-	 * 
-	 * @param args args[0] is the output Excel file name, all other args are SPDX document file names
-	 * @throws OnlineToolException Exception caught by JPype and displayed to the user
-	 */
-	public static void onlineFunction(String[] args) throws OnlineToolException{
-		// Arguments length( 14>=args length>=3 ) will checked in the Python Code
-		File outputFile = new File(args[0]);
-		if (outputFile.exists()) {
-			System.out.println("Output file "+args[0]+" already exists.");
-			// Output File name will be checked in the Python code for no clash, but if still found
-			throw new OnlineToolException("Output file "+args[0]+" already exists. Change the name of the result file.");
-		}
-		SpdxDocument[] compareDocs = new SpdxDocument[args.length-1];
-		String[] docNames = new String[args.length-1];
-		@SuppressWarnings("unchecked")
-		List<String>[] verificationErrors = new List[args.length-1];
-		for (int i = 1; i < args.length; i++) {
-			// CompareSpdxDocs.openRdfOrTagDoc and SpdxDocument.verify function already called in Python code- Verify.verify
-			docNames[i-1]  = CompareSpdxDocs.convertDocName(args[i]);
-		}
-		MultiDocumentSpreadsheet outSheet = null;
-		try {
-			outSheet = new MultiDocumentSpreadsheet(outputFile, true, false);
-			outSheet.importVerificationErrors(verificationErrors, docNames);
-			SpdxComparer comparer = new SpdxComparer();
-			comparer.compare(compareDocs);
-			outSheet.importCompareResults(comparer, docNames);
-		} catch (SpreadsheetException e) {
-			System.out.println("Unable to create output spreadsheet: "+e.getMessage());
 			throw new OnlineToolException("Unable to create output spreadsheet: "+e.getMessage());
 		} catch (InvalidSPDXAnalysisException e) {
-			System.out.println("Invalid SPDX analysis: "+e.getMessage());
 			throw new OnlineToolException("Invalid SPDX analysis: "+e.getMessage());
 		} catch (SpdxCompareException e) {
-			System.out.println("Error comparing SPDX documents: "+e.getMessage());
 			throw new OnlineToolException("Error comparing SPDX documents: "+e.getMessage());
 		} finally {
 			if (outSheet != null) {
 				try {
 					outSheet.close();
 				} catch (SpreadsheetException e) {
-					System.out.println("Warning - error closing spreadsheet: "+e.getMessage());
 					throw new OnlineToolException("Warning - error closing spreadsheet: "+e.getMessage());
 				}
 			}

--- a/src/org/spdx/tools/OnlineToolException.java
+++ b/src/org/spdx/tools/OnlineToolException.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2017 Source Auditor Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+*/
+package org.spdx.tools;
+
+/**
+ * Default Exception thrown to the Onlien Tool
+ * 
+ * @author Rohit Lodha
+ *
+ */
+
+public class OnlineToolException extends Exception {
+	
+	/**
+	 * 
+	 */
+	public OnlineToolException() {
+	}
+	
+	/**
+	 * 
+	 * @param arg0
+	 */
+	public OnlineToolException(String arg0) {
+		super(arg0);
+	}
+	
+	/**
+	 * 
+	 * @param arg0
+	 */
+	public OnlineToolException(Throwable arg0) {
+		super(arg0);
+	}
+	
+	/**
+	 * 
+	 * @param arg0
+	 * @param arg1
+	 */
+	public OnlineToolException(String arg0, Throwable arg1) {
+		super(arg0, arg1);
+	}
+	
+	/**
+	 * 
+	 * @param arg0
+	 * @param arg1
+	 * @param arg2
+	 * @param arg3
+	 */
+	public OnlineToolException(String arg0, Throwable arg1, boolean arg2, boolean arg3) {
+		super(arg0, arg1, arg2, arg3);
+	}
+
+}

--- a/src/org/spdx/tools/OnlineToolException.java
+++ b/src/org/spdx/tools/OnlineToolException.java
@@ -17,7 +17,7 @@
 package org.spdx.tools;
 
 /**
- * Default Exception thrown to the Onlien Tool
+ * Default Exception thrown to the Online Tool
  * 
  * @author Rohit Lodha
  *

--- a/src/org/spdx/tools/RdfToHtml.java
+++ b/src/org/spdx/tools/RdfToHtml.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -206,7 +207,7 @@ public class RdfToHtml {
 	 * @throws OnlineToolException Exception caught by JPype and displayed to the user
 	 * 
 	 */
-	public static void onlineFunction(String[] args) throws OnlineToolException{
+	public static List<String> onlineFunction(String[] args) throws OnlineToolException{
 		// Arguments length(args length== 2 ) will checked in the Python Code
 		File spdxFile = new File(args[0]);
 		// Output File name will be checked in the Python code for no clash, but if still found
@@ -234,7 +235,18 @@ public class RdfToHtml {
 		} catch (InvalidSPDXAnalysisException e2) {
 			System.out.println("Invalid SPDX Document: "+e2.getMessage());
 			throw new OnlineToolException("Invalid SPDX Document: "+e2.getMessage());
+		} catch (Exception e) {
+			System.out.println("Error creating SPDX Document: "+e.getMessage());
+			throw new OnlineToolException("Error creating SPDX Document: "+e.getMessage(),e);
 		}
+		List<String> verify = new ArrayList<String>();
+		verify = doc.verify();
+	    if (verify != null && verify.size() > 0) {
+	         System.out.println("Warning: The following verifications failed for the resultant SPDX RDF file:");
+	         for (int i = 0; i < verify.size(); i++) {
+	             System.out.println("\t" + verify.get(i));
+	         }
+	    }
 		String documentName = doc.getName();
 		List<File> filesToCreate = Lists.newArrayList();
 		String docHtmlFilePath = outputDirectory.getPath() + File.separator + documentName + DOC_HTML_FILE_POSTFIX;
@@ -299,6 +311,7 @@ public class RdfToHtml {
 				writer = null;
 			}
 		}
+		return verify;
 	}
 	
 	/**

--- a/src/org/spdx/tools/RdfToHtml.java
+++ b/src/org/spdx/tools/RdfToHtml.java
@@ -201,6 +201,107 @@ public class RdfToHtml {
 	}
 	
 	/**
+	 * 
+	 * @param args args[0] is the RDF file to be converted, args[1] is the result HTML file name
+	 * @throws OnlineToolException Exception caught by JPype and displayed to the user
+	 * 
+	 */
+	public static void onlineFunction(String[] args) throws OnlineToolException{
+		// Arguments length(args length== 2 ) will checked in the Python Code
+		File spdxFile = new File(args[0]);
+		// Output File name will be checked in the Python code for no clash, but if still found
+		if (!spdxFile.exists()) {
+			System.out.println("SPDX File "+args[0]+" does not exist.");
+			throw new OnlineToolException("SPDX file " + args[0] +" does not exists.");
+		}
+		if (!spdxFile.canRead()) {
+			System.out.println("Can not read SPDX File "+args[0]+".  Check permissions on the file.");
+			throw new OnlineToolException("Can not read SPDX File "+args[0]+".  Check permissions on the file.");
+		}
+		File outputDirectory = new File(args[1]);
+		if (!outputDirectory.exists()) {
+			if (!outputDirectory.mkdirs()) {
+				System.out.println("Unable to create output directory");
+				throw new OnlineToolException("Unable to create output directory");
+			}
+		}
+		SpdxDocument doc = null;
+		try {
+			doc = SPDXDocumentFactory.createSpdxDocument(args[0]);
+		} catch (IOException e2) {
+			System.out.println("IO Error creating the SPDX document");
+			throw new OnlineToolException("IO Error creating the SPDX document");
+		} catch (InvalidSPDXAnalysisException e2) {
+			System.out.println("Invalid SPDX Document: "+e2.getMessage());
+			throw new OnlineToolException("Invalid SPDX Document: "+e2.getMessage());
+		}
+		String documentName = doc.getName();
+		List<File> filesToCreate = Lists.newArrayList();
+		String docHtmlFilePath = outputDirectory.getPath() + File.separator + documentName + DOC_HTML_FILE_POSTFIX;
+		File docHtmlFile = new File(docHtmlFilePath);
+		filesToCreate.add(docHtmlFile);
+		String snippetHtmlFilePath = outputDirectory.getPath() + File.separator + SNIPPET_FILE_NAME;
+		File snippetHtmlFile = new File(snippetHtmlFilePath);
+		filesToCreate.add(snippetHtmlFile);
+		String licenseHtmlFilePath = outputDirectory.getPath() + File.separator + documentName + LICENSE_HTML_FILE_POSTFIX;
+		File licenseHtmlFile = new File(licenseHtmlFilePath);
+		filesToCreate.add(licenseHtmlFile);
+		String docFilesHtmlFilePath = outputDirectory.getPath() + File.separator + documentName + DOCUMENT_FILE_HTML_FILE_POSTFIX;
+		File docFilesHtmlFile = new File(docFilesHtmlFilePath);
+		filesToCreate.add(docFilesHtmlFile);
+		List<SpdxPackage> pkgs = null;
+		try {
+			pkgs = doc.getDocumentContainer().findAllPackages();
+		} catch (InvalidSPDXAnalysisException e1) {
+			System.out.println("Error getting packages from the SPDX document: "+e1.getMessage());
+			throw new OnlineToolException("Error getting packages from the SPDX document: "+e1.getMessage());
+		}
+		Iterator<SpdxPackage> iter = pkgs.iterator();
+		while (iter.hasNext()) {
+			String packageName = iter.next().getName();
+			String packageHtmlFilePath = outputDirectory.getPath() + File.separator + packageName + 
+					PACKAGE_HTML_FILE_POSTFIX;
+			File packageHtmlFile = new File(packageHtmlFilePath);
+			filesToCreate.add(packageHtmlFile);
+			String packageFilesHtmlFilePath = outputDirectory.getPath() + File.separator + packageName + 
+					PACKAGE_FILE_HTML_FILE_POSTFIX;
+			File packageFilesHtmlFile = new File(packageFilesHtmlFilePath);
+			filesToCreate.add(packageFilesHtmlFile);
+		}
+		Iterator<File> fileIter = filesToCreate.iterator();
+		while (fileIter.hasNext()) {
+			File file = fileIter.next();
+			if (file.exists()) {
+				System.out.println("File "+file.getName()+" already exists.");
+				throw new OnlineToolException("File "+file.getName()+" already exists.");
+			}
+		}
+		Writer writer = null;
+		try {
+			rdfToHtml(doc, docHtmlFile, licenseHtmlFile, snippetHtmlFile, docFilesHtmlFile);
+		} catch (IOException e) {
+			System.out.println("IO Error opening SPDX Document");
+			throw new OnlineToolException("IO Error opening SPDX Document");
+		} catch (InvalidSPDXAnalysisException e) {
+			System.out.println("Invalid SPDX Document: "+e.getMessage());
+			throw new OnlineToolException("Invalid SPDX Document: "+e.getMessage());
+		} catch (MustacheException e) {
+			System.out.println("Unexpected error reading the HTML template: "+e.getMessage());
+			throw new OnlineToolException("Unexpected error reading the HTML template: "+e.getMessage());
+		} finally {
+			if (writer != null) {
+				try {
+					writer.close();
+				} catch (IOException e) {
+					System.out.println("Warning: error closing HTML file: "+e.getMessage());
+					throw new OnlineToolException("Warning: error closing HTML file: "+e.getMessage());
+				}
+				writer = null;
+			}
+		}
+	}
+	
+	/**
 	 * Display usage information to console
 	 */
 	private static void usage() {

--- a/src/org/spdx/tools/RdfToSpreadsheet.java
+++ b/src/org/spdx/tools/RdfToSpreadsheet.java
@@ -163,8 +163,11 @@ public class RdfToSpreadsheet {
 			System.out.print("Error creating SPDX Document: "+ex.getMessage());
 			throw new OnlineToolException("Error creating SPDX Document: "+ex.getMessage());
 		} catch (IOException e) {
-			System.out.print("Unable to open file :"+args[0]+", "+e.getMessage());
-			throw new OnlineToolException("Unable to open file :"+args[0]+", "+e.getMessage());
+			System.out.print("Error creating SPDX Document:"+args[0]+", "+e.getMessage());
+			throw new OnlineToolException("Error creating SPDX Document:"+args[0]+", "+e.getMessage());
+		} catch (Exception e) {
+			System.out.println("Error creating SPDX Document: "+e.getMessage());
+			throw new OnlineToolException("Error creating SPDX Document: "+e.getMessage(),e);
 		}
 		List<String> verify = new ArrayList<String>();
         if (doc != null) {

--- a/src/org/spdx/tools/RdfToSpreadsheet.java
+++ b/src/org/spdx/tools/RdfToSpreadsheet.java
@@ -86,55 +86,13 @@ public class RdfToSpreadsheet {
 			usage();
 			return;
 		}
-		File spdxRdfFile = new File(args[0]);
-		if (!spdxRdfFile.exists()) {
-			System.out.printf("Error: File %1$s does not exist.%n", args[0]);
-			return;
-		}
-		File spdxSpreadsheetFile = new File(args[1]);
-		if (spdxSpreadsheetFile.exists()) {
-			System.out.println("Spreadsheet file already exists - please specify a new file.");
-			return;
-		}
-		SpdxDocument doc = null;
 		try {
-			doc = SPDXDocumentFactory.createSpdxDocument(args[0]);
-		} catch (InvalidSPDXAnalysisException ex) {
-			System.out.print("Error creating SPDX Document: "+ex.getMessage());
+			onlineFunction(args);
+		} catch (OnlineToolException e){
+			System.out.println(e.getMessage());
+			usage();
 			return;
-		} catch (IOException e) {
-			System.out.print("Unable to open file :"+args[0]+", "+e.getMessage());
 		}
-        if (doc != null) {
-            SPDXSpreadsheet ss = null;
-            try {
-                ss = new SPDXSpreadsheet(spdxSpreadsheetFile, true, false);
-                copyRdfXmlToSpreadsheet(doc, ss);
-                List<String> verify = doc.verify();
-                if (verify != null && verify.size() > 0) {
-                    System.out.println("Warning: The following verifications failed for the resultant SPDX RDF file:");
-                    for (int i = 0; i < verify.size(); i++) {
-                        System.out.println("\t" + verify.get(i));
-                    }
-                }
-            } catch (SpreadsheetException e) {
-                System.out.println("Error opening or writing to spreadsheet: " + e.getMessage());
-            } catch (InvalidSPDXAnalysisException e) {
-                System.out.println("Error translating the RDF file: " + e.getMessage());
-            } catch (Exception ex) {
-                System.out.println("Unexpected error translating the RDF to spreadsheet: " + ex.getMessage());
-            } finally {
-                if (ss != null) {
-                    try {
-                        ss.close();
-                    } catch (SpreadsheetException e) {
-                        System.out.println("Error closing spreadsheet: " + e.getMessage());
-                    }
-                }
-            }
-        }else{
-            System.out.println("Error creating SPDX document reference, null reference returned");
-        }
     }
 	
 	/**
@@ -148,25 +106,20 @@ public class RdfToSpreadsheet {
 		File spdxRdfFile = new File(args[0]);
 		// Output File name will be checked in the Python code for no clash, but if still found
 		if (!spdxRdfFile.exists()) {
-			System.out.printf("Error: File %1$s does not exist.%n", args[0]);
 			throw new OnlineToolException("Error: File " + args[0] + " does not exist.");
 		}
 		File spdxSpreadsheetFile = new File(args[1]);
 		if (spdxSpreadsheetFile.exists()) {
-			System.out.println("Spreadsheet file already exists - please specify a new file.");
 			throw new OnlineToolException("Spreadsheet file already exists - please specify a new file.");
 		}
 		SpdxDocument doc = null;
 		try {
 			doc = SPDXDocumentFactory.createSpdxDocument(args[0]);
 		} catch (InvalidSPDXAnalysisException ex) {
-			System.out.print("Error creating SPDX Document: "+ex.getMessage());
 			throw new OnlineToolException("Error creating SPDX Document: "+ex.getMessage());
 		} catch (IOException e) {
-			System.out.print("Error creating SPDX Document:"+args[0]+", "+e.getMessage());
 			throw new OnlineToolException("Error creating SPDX Document:"+args[0]+", "+e.getMessage());
 		} catch (Exception e) {
-			System.out.println("Error creating SPDX Document: "+e.getMessage());
 			throw new OnlineToolException("Error creating SPDX Document: "+e.getMessage(),e);
 		}
 		List<String> verify = new ArrayList<String>();
@@ -183,26 +136,21 @@ public class RdfToSpreadsheet {
                     }
                 }
             } catch (SpreadsheetException e) {
-                System.out.println("Error opening or writing to spreadsheet: " + e.getMessage());
                 throw new OnlineToolException("Error opening or writing to spreadsheet: " + e.getMessage());
             } catch (InvalidSPDXAnalysisException e) {
-                System.out.println("Error translating the RDF file: " + e.getMessage());
                 throw new OnlineToolException("Error translating the RDF file: " + e.getMessage());
             } catch (Exception ex) {
-                System.out.println("Unexpected error translating the RDF to spreadsheet: " + ex.getMessage());
                 throw new OnlineToolException("Unexpected error translating the RDF to spreadsheet: " + ex.getMessage());
             } finally {
                 if (ss != null) {
                     try {
                         ss.close();
                     } catch (SpreadsheetException e) {
-                        System.out.println("Error closing spreadsheet: " + e.getMessage());
                         throw new OnlineToolException("Error closing spreadsheet: " + e.getMessage());
                     }
                 }
             }
         }else{
-            System.out.println("Error creating SPDX document reference, null reference returned");
             throw new OnlineToolException("Error creating SPDX document reference, null reference returned");
         }
         return verify;

--- a/src/org/spdx/tools/RdfToSpreadsheet.java
+++ b/src/org/spdx/tools/RdfToSpreadsheet.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -135,7 +136,75 @@ public class RdfToSpreadsheet {
             System.out.println("Error creating SPDX document reference, null reference returned");
         }
     }
-
+	
+	/**
+	 * 
+	 * @param args args[0] is the RDF file to be converted, args[1] is the result HTML file name
+	 * @throws OnlineToolException Exception caught by JPype and displayed to the user
+	 * @return Warnings of the conversion, displayed to the user
+	 */
+	public static List<String> onlineFunction(String[] args) throws OnlineToolException{
+		// Arguments length(args length== 2 ) will checked in the Python Code
+		File spdxRdfFile = new File(args[0]);
+		// Output File name will be checked in the Python code for no clash, but if still found
+		if (!spdxRdfFile.exists()) {
+			System.out.printf("Error: File %1$s does not exist.%n", args[0]);
+			throw new OnlineToolException("Error: File " + args[0] + " does not exist.");
+		}
+		File spdxSpreadsheetFile = new File(args[1]);
+		if (spdxSpreadsheetFile.exists()) {
+			System.out.println("Spreadsheet file already exists - please specify a new file.");
+			throw new OnlineToolException("Spreadsheet file already exists - please specify a new file.");
+		}
+		SpdxDocument doc = null;
+		try {
+			doc = SPDXDocumentFactory.createSpdxDocument(args[0]);
+		} catch (InvalidSPDXAnalysisException ex) {
+			System.out.print("Error creating SPDX Document: "+ex.getMessage());
+			throw new OnlineToolException("Error creating SPDX Document: "+ex.getMessage());
+		} catch (IOException e) {
+			System.out.print("Unable to open file :"+args[0]+", "+e.getMessage());
+			throw new OnlineToolException("Unable to open file :"+args[0]+", "+e.getMessage());
+		}
+		List<String> verify = new ArrayList<String>();
+        if (doc != null) {
+            SPDXSpreadsheet ss = null;
+            try {
+                ss = new SPDXSpreadsheet(spdxSpreadsheetFile, true, false);
+                copyRdfXmlToSpreadsheet(doc, ss);
+                verify = doc.verify();
+                if (verify != null && verify.size() > 0) {
+                    System.out.println("Warning: The following verifications failed for the resultant SPDX RDF file:");
+                    for (int i = 0; i < verify.size(); i++) {
+                        System.out.println("\t" + verify.get(i));
+                    }
+                }
+            } catch (SpreadsheetException e) {
+                System.out.println("Error opening or writing to spreadsheet: " + e.getMessage());
+                throw new OnlineToolException("Error opening or writing to spreadsheet: " + e.getMessage());
+            } catch (InvalidSPDXAnalysisException e) {
+                System.out.println("Error translating the RDF file: " + e.getMessage());
+                throw new OnlineToolException("Error translating the RDF file: " + e.getMessage());
+            } catch (Exception ex) {
+                System.out.println("Unexpected error translating the RDF to spreadsheet: " + ex.getMessage());
+                throw new OnlineToolException("Unexpected error translating the RDF to spreadsheet: " + ex.getMessage());
+            } finally {
+                if (ss != null) {
+                    try {
+                        ss.close();
+                    } catch (SpreadsheetException e) {
+                        System.out.println("Error closing spreadsheet: " + e.getMessage());
+                        throw new OnlineToolException("Error closing spreadsheet: " + e.getMessage());
+                    }
+                }
+            }
+        }else{
+            System.out.println("Error creating SPDX document reference, null reference returned");
+            throw new OnlineToolException("Error creating SPDX document reference, null reference returned");
+        }
+        return verify;
+	}
+	
 	@SuppressWarnings("deprecation")
 	public static void copyRdfXmlToSpreadsheet(SpdxDocument doc,
 			SPDXSpreadsheet ss) throws InvalidSPDXAnalysisException, SpreadsheetException {

--- a/src/org/spdx/tools/RdfToTag.java
+++ b/src/org/spdx/tools/RdfToTag.java
@@ -69,79 +69,12 @@ public class RdfToTag {
 			System.out.printf("Warning: Extra arguments will be ignored%n");
 			usage();
 		}
-		File spdxRdfFile = new File(args[0]);
-		if (!spdxRdfFile.exists()) {
-			System.out.printf("RDF file %1$s does not exists.%n", args[0]);
-			return;
-		}
-		File spdxTagFile = new File(args[1]);
-		if (spdxTagFile.exists()) {
-			System.out
-					.printf("Error: File %1$s already exists - please specify a new file.%n",
-							args[1]);
-			return;
-		}
 		try {
-			if (!spdxTagFile.createNewFile()) {
-				System.out.println("Could not create the new SPDX Tag file "
-						+ args[1]);
-				usage();
-				return;
-			}
-		} catch (IOException e1) {
-			System.out.println("Could not create the new SPDX Tag file "
-					+ args[1]);
-			System.out.println("due to error " + e1.getMessage());
+			onlineFunction(args);
+		} catch (OnlineToolException e){
+			System.out.println(e.getMessage());
 			usage();
 			return;
-		}
-		PrintWriter out = null;
-		try {
-			try {
-				out = new PrintWriter(spdxTagFile, "UTF-8");
-			} catch (IOException e1) {
-				System.out.println("Could not write to the new SPDX Tag file "
-						+ args[1]);
-				System.out.println("due to error " + e1.getMessage());
-				usage();
-				return;
-			}
-			SpdxDocument doc = null;
-			try {
-				doc = SPDXDocumentFactory.createSpdxDocument(args[0]);
-			} catch (Exception ex) {
-				System.out.print("Error creating SPDX Document: "
-						+ ex.getMessage());
-				return;
-			}
-			try {
-				List<String> verify = new LinkedList<String>(); // doc.verify();
-				if (verify.size() > 0) {
-					System.out
-							.println("This SPDX Document is not valid due to:");
-					for (int i = 0; i < verify.size(); i++) {
-						System.out.println("\t" + verify.get(i));
-					}
-				}
-				// read the tag-value constants from a file
-				Properties constants = CommonCode
-						.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
-				// print document to a file using tag-value format
-				CommonCode.printDoc(doc, out, constants);
-			} catch (InvalidSPDXAnalysisException e) {
-				System.out
-						.print("Error transalting SPDX Document to tag-value format: "
-								+ e.getMessage());
-				return;
-			} catch (Exception e) {
-				System.out.print("Unexpected error displaying SPDX Document: "
-						+ e.getMessage());
-			}
-		} finally {
-			if (out != null) {
-				out.flush();
-				out.close();
-			}
 		}
 	}
 
@@ -156,26 +89,18 @@ public class RdfToTag {
 		File spdxRdfFile = new File(args[0]);
 		// Output File name will be checked in the Python code for no clash, but if still found
 		if (!spdxRdfFile.exists()) {
-			System.out.printf("RDF file %1$s does not exists.%n", args[0]);
 			throw new OnlineToolException("RDF file " + args[0] +" does not exists.");
 		}
 		File spdxTagFile = new File(args[1]);
 		if (spdxTagFile.exists()) {
-			System.out.printf("Error: File %1$s already exists - please specify a new file.%n",
-							args[1]);
 			throw new OnlineToolException("Error: File " +args[1] +" already exists - please specify a new file.");
 		}
 		try {
 			if (!spdxTagFile.createNewFile()) {
-				System.out.println("Could not create the new SPDX Tag file "
-						+ args[1]);
 				throw new OnlineToolException("Could not create the new SPDX Tag file "
 						+ args[1]);
 			}
 		} catch (IOException e1) {
-			System.out.println("Could not create the new SPDX Tag file "
-					+ args[1]);
-			System.out.println("due to error " + e1.getMessage());
 			throw new OnlineToolException("Could not create the new SPDX Tag file " + args[1] + "due to error " + e1.getMessage());
 		}
 		PrintWriter out = null;
@@ -184,9 +109,6 @@ public class RdfToTag {
 			try {
 				out = new PrintWriter(spdxTagFile, "UTF-8");
 			} catch (IOException e1) {
-				System.out.println("Could not write to the new SPDX Tag file "
-						+ args[1]);
-				System.out.println("due to error " + e1.getMessage());
 				throw new OnlineToolException("Could not write to the new SPDX Tag file "
 						+ args[1] +  "due to error " + e1.getMessage());
 				
@@ -195,13 +117,10 @@ public class RdfToTag {
 			try {
 				doc = SPDXDocumentFactory.createSpdxDocument(args[0]);
 			} catch (InvalidSPDXAnalysisException ex) {
-				System.out.print("Error creating SPDX Document: "+ex.getMessage());
 				throw new OnlineToolException("Error creating SPDX Document: "+ex.getMessage());
 			} catch (IOException e) {
-				System.out.print("Error creating SPDX Document:"+args[0]+", "+e.getMessage());
 				throw new OnlineToolException("Unable to open file :"+args[0]+", "+e.getMessage());
 			} catch (Exception e) {
-				System.out.println("Error creating SPDX Document: "+e.getMessage());
 				throw new OnlineToolException("Error creating SPDX Document: "+e.getMessage(),e);
 			}
 
@@ -220,14 +139,9 @@ public class RdfToTag {
 				// print document to a file using tag-value format
 				CommonCode.printDoc(doc, out, constants);
 			} catch (InvalidSPDXAnalysisException e) {
-				System.out
-						.print("Error transalting SPDX Document to tag-value format: "
-								+ e.getMessage());
 				throw new OnlineToolException("Error transalting SPDX Document to tag-value format: "
 						+ e.getMessage());
 			} catch (Exception e) {
-				System.out.print("Unexpected error displaying SPDX Document: "
-						+ e.getMessage());
 				throw new OnlineToolException("Unexpected error displaying SPDX Document: "
 						+ e.getMessage());
 			}

--- a/src/org/spdx/tools/RdfToTag.java
+++ b/src/org/spdx/tools/RdfToTag.java
@@ -145,6 +145,96 @@ public class RdfToTag {
 		}
 	}
 
+	/**
+	 * 
+	 * @param args args[0] is the RDF file to be converted, args[1] is the result Tag file name
+	 * @throws OnlineToolException Exception caught by JPype and displayed to the user
+	 * @return Warnings of the conversion, displayed to the user
+	 */
+	public static List<String> onlineFunction(String[] args) throws OnlineToolException{
+		// Arguments length(args length== 2 ) will checked in the Python Code
+		File spdxRdfFile = new File(args[0]);
+		// Output File name will be checked in the Python code for no clash, but if still found
+		if (!spdxRdfFile.exists()) {
+			System.out.printf("RDF file %1$s does not exists.%n", args[0]);
+			throw new OnlineToolException("RDF file " + args[0] +" does not exists.");
+		}
+		File spdxTagFile = new File(args[1]);
+		if (spdxTagFile.exists()) {
+			System.out.printf("Error: File %1$s already exists - please specify a new file.%n",
+							args[1]);
+			throw new OnlineToolException("Error: File " +args[1] +" already exists - please specify a new file.");
+		}
+		try {
+			if (!spdxTagFile.createNewFile()) {
+				System.out.println("Could not create the new SPDX Tag file "
+						+ args[1]);
+				throw new OnlineToolException("Could not create the new SPDX Tag file "
+						+ args[1]);
+			}
+		} catch (IOException e1) {
+			System.out.println("Could not create the new SPDX Tag file "
+					+ args[1]);
+			System.out.println("due to error " + e1.getMessage());
+			throw new OnlineToolException("Could not create the new SPDX Tag file " + args[1] + "due to error " + e1.getMessage());
+		}
+		PrintWriter out = null;
+		List<String> verify = new LinkedList<String>();
+		try {
+			try {
+				out = new PrintWriter(spdxTagFile, "UTF-8");
+			} catch (IOException e1) {
+				System.out.println("Could not write to the new SPDX Tag file "
+						+ args[1]);
+				System.out.println("due to error " + e1.getMessage());
+				throw new OnlineToolException("Could not write to the new SPDX Tag file "
+						+ args[1] +  "due to error " + e1.getMessage());
+				
+			}
+			SpdxDocument doc = null;
+			try {
+				doc = SPDXDocumentFactory.createSpdxDocument(args[0]);
+			} catch (Exception ex) {
+				System.out.print("Error creating SPDX Document: "
+						+ ex.getMessage());
+				throw new OnlineToolException("Error creating SPDX Document: "
+						+ ex.getMessage());
+			}
+			try {
+				//verify = new LinkedList<String>(); // doc.verify();
+				if (verify.size() > 0) {
+					System.out
+							.println("This SPDX Document is not valid due to:");
+					for (int i = 0; i < verify.size(); i++) {
+						System.out.println("\t" + verify.get(i));
+					}
+				}
+				// read the tag-value constants from a file
+				Properties constants = CommonCode
+						.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
+				// print document to a file using tag-value format
+				CommonCode.printDoc(doc, out, constants);
+			} catch (InvalidSPDXAnalysisException e) {
+				System.out
+						.print("Error transalting SPDX Document to tag-value format: "
+								+ e.getMessage());
+				throw new OnlineToolException("Error transalting SPDX Document to tag-value format: "
+						+ e.getMessage());
+			} catch (Exception e) {
+				System.out.print("Unexpected error displaying SPDX Document: "
+						+ e.getMessage());
+				throw new OnlineToolException("Unexpected error displaying SPDX Document: "
+						+ e.getMessage());
+			}
+		} finally {
+			if (out != null) {
+				out.flush();
+				out.close();
+			}
+		}
+		return verify;
+	}
+	
 	private static void usage() {
 		System.out
 				.println("Usage: RdfToTag rdfxmlfile.rdf spdxfile.spdx\n"

--- a/src/org/spdx/tools/RdfToTag.java
+++ b/src/org/spdx/tools/RdfToTag.java
@@ -194,14 +194,19 @@ public class RdfToTag {
 			SpdxDocument doc = null;
 			try {
 				doc = SPDXDocumentFactory.createSpdxDocument(args[0]);
-			} catch (Exception ex) {
-				System.out.print("Error creating SPDX Document: "
-						+ ex.getMessage());
-				throw new OnlineToolException("Error creating SPDX Document: "
-						+ ex.getMessage());
+			} catch (InvalidSPDXAnalysisException ex) {
+				System.out.print("Error creating SPDX Document: "+ex.getMessage());
+				throw new OnlineToolException("Error creating SPDX Document: "+ex.getMessage());
+			} catch (IOException e) {
+				System.out.print("Error creating SPDX Document:"+args[0]+", "+e.getMessage());
+				throw new OnlineToolException("Unable to open file :"+args[0]+", "+e.getMessage());
+			} catch (Exception e) {
+				System.out.println("Error creating SPDX Document: "+e.getMessage());
+				throw new OnlineToolException("Error creating SPDX Document: "+e.getMessage(),e);
 			}
+
 			try {
-				//verify = new LinkedList<String>(); // doc.verify();
+				verify = doc.verify();
 				if (verify.size() > 0) {
 					System.out
 							.println("This SPDX Document is not valid due to:");

--- a/src/org/spdx/tools/SpreadsheetToRDF.java
+++ b/src/org/spdx/tools/SpreadsheetToRDF.java
@@ -93,70 +93,12 @@ public class SpreadsheetToRDF {
 			usage();
 			return;
 		}
-		File spdxSpreadsheetFile = new File(args[0]);
-		if (!spdxSpreadsheetFile.exists()) {
-			System.out.printf("Spreadsheet file %1$s does not exists.%n", args[0]);
-			return;
-		}
-		File spdxRdfFile = new File(args[1]);
-		if (spdxRdfFile.exists()) {
-			System.out.printf("Error: File %1$s already exists - please specify a new file.%n", args[1]);
-			return;
-		}
-	
 		try {
-			if (!spdxRdfFile.createNewFile()) {
-				System.out.println("Could not create the new SPDX RDF file "+args[1]);
-				usage();
-				return;
-			}
-		} catch (IOException e1) {
-			System.out.println("Could not create the new SPDX RDF file "+args[1]);
-			System.out.println("due to error "+e1.getMessage());
+			onlineFunction(args);
+		} catch (OnlineToolException e){
+			System.out.println(e.getMessage());
 			usage();
 			return;
-		}
-		FileOutputStream out;
-		try {
-			out = new FileOutputStream(spdxRdfFile);
-		} catch (FileNotFoundException e1) {
-			System.out.println("Could not write to the new SPDX RDF file "+args[1]);
-			System.out.println("due to error "+e1.getMessage());
-			usage();
-			return;
-		}
-
-		SPDXSpreadsheet ss = null;
-		try {
-			ss = new SPDXSpreadsheet(spdxSpreadsheetFile, false, true);
-			SpdxDocument analysis = copySpreadsheetToSPDXAnalysis(ss);
-			List<String> verify = analysis.verify();
-			if (verify.size() > 0) {
-				System.out.println("Warning: The following verification errors were found in the resultant SPDX Document:");
-				for (int i = 0; i < verify.size(); i++) {
-					System.out.println("\t"+verify.get(i));
-				}
-			}
-			analysis.getDocumentContainer().getModel().write(out, "RDF/XML-ABBREV");
-		} catch (SpreadsheetException e) {
-			System.out.println("Error creating or writing to spreadsheet: "+e.getMessage());
-		} catch (InvalidSPDXAnalysisException e) {
-			System.out.println("Error translating the RDF file: "+e.getMessage());
-		} finally {
-			if (ss != null) {
-				try {
-					ss.close();
-				} catch (SpreadsheetException e) {
-					System.out.println("Error closing spreadsheet: "+e.getMessage());
-				}
-			}
-			if (out != null) {
-				try {
-					out.close();
-				} catch (IOException e) {
-					System.out.println("Error closing RDF file: "+e.getMessage());
-				}
-			}
 		}
 	}
 	
@@ -170,32 +112,25 @@ public class SpreadsheetToRDF {
 		// Arguments length(args length== 2 ) will checked in the Python Code
 		File spdxSpreadsheetFile = new File(args[0]);
 		if (!spdxSpreadsheetFile.exists()) {
-			System.out.printf("Spreadsheet file %1$s does not exists.%n", args[0]);
 			throw new OnlineToolException("Spreadsheet file " + "does not exists.");
 		}
 		File spdxRdfFile = new File(args[1]);
 		// Output File name will be checked in the Python code for no clash, but if still found
 		if (spdxRdfFile.exists()) {
-			System.out.printf("Error: File %1$s already exists - please specify a new file.%n", args[1]);
 			throw new OnlineToolException("Error: File " + args[1] + " already exists - please specify a new file.");
 		}
 	
 		try {
 			if (!spdxRdfFile.createNewFile()) {
-				System.out.println("Could not create the new SPDX RDF file "+args[1]);
 				throw new OnlineToolException("Could not create the new SPDX RDF file "+args[1]);
 			}
 		} catch (IOException e1) {
-			System.out.println("Could not create the new SPDX RDF file "+args[1]);
-			System.out.println("due to error "+e1.getMessage());
 			throw new OnlineToolException("Could not create the new SPDX RDF file "+args[1] + "due to error "+e1.getMessage() );
 		}
 		FileOutputStream out;
 		try {
 			out = new FileOutputStream(spdxRdfFile);
 		} catch (FileNotFoundException e1) {
-			System.out.println("Could not write to the new SPDX RDF file "+args[1]);
-			System.out.println("due to error "+e1.getMessage());
 			throw new OnlineToolException("Could not write to the new SPDX RDF file "+args[1] +"due to error "+e1.getMessage() );
 		}
 
@@ -213,17 +148,14 @@ public class SpreadsheetToRDF {
 			}
 			analysis.getDocumentContainer().getModel().write(out, "RDF/XML-ABBREV");
 		} catch (SpreadsheetException e) {
-			System.out.println("Error creating or writing to spreadsheet: "+e.getMessage());
 			throw new OnlineToolException("Error creating or writing to spreadsheet: "+e.getMessage());
 		} catch (InvalidSPDXAnalysisException e) {
-			System.out.println("Error translating the RDF file: "+e.getMessage());
 			throw new OnlineToolException("Error translating the RDF file: "+e.getMessage());
 		} finally {
 			if (ss != null) {
 				try {
 					ss.close();
 				} catch (SpreadsheetException e) {
-					System.out.println("Error closing spreadsheet: "+e.getMessage());
 					throw new OnlineToolException("Error closing spreadsheet: "+e.getMessage());
 				}
 			}
@@ -231,7 +163,6 @@ public class SpreadsheetToRDF {
 				try {
 					out.close();
 				} catch (IOException e) {
-					System.out.println("Error closing RDF file: "+e.getMessage());
 					throw new OnlineToolException("Error closing RDF file: "+e.getMessage());
 				}
 			}

--- a/src/org/spdx/tools/SpreadsheetToRDF.java
+++ b/src/org/spdx/tools/SpreadsheetToRDF.java
@@ -22,6 +22,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -159,6 +160,84 @@ public class SpreadsheetToRDF {
 		}
 	}
 	
+	/**
+	 * 
+	 * @param args args[0] is the Spreadsheet file to be converted, args[1] is the result RDF file name
+	 * @throws OnlineToolException Exception caught by JPype and displayed to the user
+	 * @return Warnings of the conversion, displayed to the user
+	 */
+	public static List<String> onlineFunction(String[] args) throws OnlineToolException{
+		// Arguments length(args length== 2 ) will checked in the Python Code
+		File spdxSpreadsheetFile = new File(args[0]);
+		if (!spdxSpreadsheetFile.exists()) {
+			System.out.printf("Spreadsheet file %1$s does not exists.%n", args[0]);
+			throw new OnlineToolException("Spreadsheet file " + "does not exists.");
+		}
+		File spdxRdfFile = new File(args[1]);
+		// Output File name will be checked in the Python code for no clash, but if still found
+		if (spdxRdfFile.exists()) {
+			System.out.printf("Error: File %1$s already exists - please specify a new file.%n", args[1]);
+			throw new OnlineToolException("Error: File " + args[1] + " already exists - please specify a new file.");
+		}
+	
+		try {
+			if (!spdxRdfFile.createNewFile()) {
+				System.out.println("Could not create the new SPDX RDF file "+args[1]);
+				throw new OnlineToolException("Could not create the new SPDX RDF file "+args[1]);
+			}
+		} catch (IOException e1) {
+			System.out.println("Could not create the new SPDX RDF file "+args[1]);
+			System.out.println("due to error "+e1.getMessage());
+			throw new OnlineToolException("Could not create the new SPDX RDF file "+args[1] + "due to error "+e1.getMessage() );
+		}
+		FileOutputStream out;
+		try {
+			out = new FileOutputStream(spdxRdfFile);
+		} catch (FileNotFoundException e1) {
+			System.out.println("Could not write to the new SPDX RDF file "+args[1]);
+			System.out.println("due to error "+e1.getMessage());
+			throw new OnlineToolException("Could not write to the new SPDX RDF file "+args[1] +"due to error "+e1.getMessage() );
+		}
+
+		SPDXSpreadsheet ss = null;
+		List<String> verify = new ArrayList<String>();
+		try {
+			ss = new SPDXSpreadsheet(spdxSpreadsheetFile, false, true);
+			SpdxDocument analysis = copySpreadsheetToSPDXAnalysis(ss);
+			verify = analysis.verify();
+			if (verify.size() > 0) {
+				System.out.println("Warning: The following verification errors were found in the resultant SPDX Document:");
+				for (int i = 0; i < verify.size(); i++) {
+					System.out.println("\t"+verify.get(i));
+				}
+			}
+			analysis.getDocumentContainer().getModel().write(out, "RDF/XML-ABBREV");
+		} catch (SpreadsheetException e) {
+			System.out.println("Error creating or writing to spreadsheet: "+e.getMessage());
+			throw new OnlineToolException("Error creating or writing to spreadsheet: "+e.getMessage());
+		} catch (InvalidSPDXAnalysisException e) {
+			System.out.println("Error translating the RDF file: "+e.getMessage());
+			throw new OnlineToolException("Error translating the RDF file: "+e.getMessage());
+		} finally {
+			if (ss != null) {
+				try {
+					ss.close();
+				} catch (SpreadsheetException e) {
+					System.out.println("Error closing spreadsheet: "+e.getMessage());
+					throw new OnlineToolException("Error closing spreadsheet: "+e.getMessage());
+				}
+			}
+			if (out != null) {
+				try {
+					out.close();
+				} catch (IOException e) {
+					System.out.println("Error closing RDF file: "+e.getMessage());
+					throw new OnlineToolException("Error closing RDF file: "+e.getMessage());
+				}
+			}
+		}
+		return verify;
+	}
 	public static SpdxDocument copySpreadsheetToSPDXAnalysis(SPDXSpreadsheet ss) throws SpreadsheetException, InvalidSPDXAnalysisException {
 		String pkgUrl = ss.getOriginsSheet().getNamespace() + "#" + SpdxRdfConstants.SPDX_DOCUMENT_ID;
 		if (!SpdxVerificationHelper.isValidUri(pkgUrl)) {

--- a/src/org/spdx/tools/SpreadsheetToTag.java
+++ b/src/org/spdx/tools/SpreadsheetToTag.java
@@ -60,86 +60,12 @@ public class SpreadsheetToTag {
 			usage();
 			return;
 		}
-		File spdxSpreadsheetFile = new File(args[0]);
-		if (!spdxSpreadsheetFile.exists()) {
-			System.out.printf("Spreadsheet file %1$s does not exists.%n",
-					args[0]);
-			return;
-		}
-		File spdxTagFile = new File(args[1]);
-		if (spdxTagFile.exists()) {
-			System.out
-					.printf("Error: File %1$s already exists - please specify a new file.%n",
-							args[1]);
-			return;
-		}
-
 		try {
-			if (!spdxTagFile.createNewFile()) {
-				System.out.println("Could not create the new SPDX Tag file "
-						+ args[1]);
-				usage();
-				return;
-			}
-		} catch (IOException e1) {
-			System.out.println("Could not create the new SPDX Tag file "
-					+ args[1]);
-			System.out.println("due to error " + e1.getMessage());
+			onlineFunction(args);
+		} catch (OnlineToolException e){
+			System.out.println(e.getMessage());
 			usage();
 			return;
-		}
-		PrintWriter out = null;
-		try {
-			try {
-				out = new PrintWriter(spdxTagFile, "UTF-8");
-			} catch (IOException e1) {
-				System.out.println("Could not write to the new SPDX Tag file "
-						+ args[1]);
-				System.out.println("due to error " + e1.getMessage());
-				usage();
-				return;
-			}
-
-			SPDXSpreadsheet ss = null;
-			try {
-				ss = new SPDXSpreadsheet(spdxSpreadsheetFile, false, true);
-				SpdxDocument analysis = SpreadsheetToRDF.copySpreadsheetToSPDXAnalysis(ss);
-				List<String> verify = analysis.verify();
-				if (verify.size() > 0) {
-					System.out
-							.println("Warning: The following verification errors were found in the resultant SPDX Document:");
-					for (int i = 0; i < verify.size(); i++) {
-						System.out.println("\t" + verify.get(i));
-					}
-				}
-				// read the constants from a file
-				Properties constants = CommonCode
-						.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
-				CommonCode.printDoc(analysis, out, constants);
-			} catch (SpreadsheetException e) {
-				System.out.println("Error creating or writing to spreadsheet: "
-						+ e.getMessage());
-			} catch (InvalidSPDXAnalysisException e) {
-				System.out.println("Error translating the Tag file: "
-						+ e.getMessage());
-			} catch (Exception e) {
-				System.out.print("Unexpected error converting SPDX Document: "
-						+ e.getMessage());
-			} finally {
-				if (ss != null) {
-					try {
-						ss.close();
-					} catch (SpreadsheetException e) {
-						System.out.println("Error closing spreadsheet: "
-								+ e.getMessage());
-					}
-				}
-			}
-		} finally {
-			if (out != null) {
-				out.flush();
-				out.close();
-			}
 		}
 	}
 	
@@ -153,30 +79,20 @@ public class SpreadsheetToTag {
 		// Arguments length(args length== 2 ) will checked in the Python Code
 		File spdxSpreadsheetFile = new File(args[0]);
 		if (!spdxSpreadsheetFile.exists()) {
-			System.out.printf("Spreadsheet file %1$s does not exists.%n",
-					args[0]);
 			throw new OnlineToolException("Spreadsheet file " + args[0] + " does not exists.");
 		}
 		File spdxTagFile = new File(args[1]);
 		// Output File name will be checked in the Python code for no clash, but if still found
 		if (spdxTagFile.exists()) {
-			System.out
-					.printf("Error: File %1$s already exists - please specify a new file.%n",
-							args[1]);
 			throw new OnlineToolException("Error: File " + args[1] +" already exists - please specify a new file.");
 		}
 
 		try {
 			if (!spdxTagFile.createNewFile()) {
-				System.out.println("Could not create the new SPDX Tag file "
-						+ args[1]);
 				throw new OnlineToolException("Could not create the new SPDX Tag file "
 						+ args[1]);
 			}
 		} catch (IOException e1) {
-			System.out.println("Could not create the new SPDX Tag file "
-					+ args[1]);
-			System.out.println("due to error " + e1.getMessage());
 			throw new OnlineToolException("Could not create the new SPDX Tag file "
 					+ args[1] + "due to error " + e1.getMessage());
 		}
@@ -186,9 +102,6 @@ public class SpreadsheetToTag {
 			try {
 				out = new PrintWriter(spdxTagFile, "UTF-8");
 			} catch (IOException e1) {
-				System.out.println("Could not write to the new SPDX Tag file "
-						+ args[1]);
-				System.out.println("due to error " + e1.getMessage());
 				throw new OnlineToolException("Could not write to the new SPDX Tag file "
 						+ args[1] + "due to error " + e1.getMessage());
 			}
@@ -210,18 +123,12 @@ public class SpreadsheetToTag {
 						.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
 				CommonCode.printDoc(analysis, out, constants);
 			} catch (SpreadsheetException e) {
-				System.out.println("Error creating or writing to spreadsheet: "
-						+ e.getMessage());
 				throw new OnlineToolException("Error creating or writing to spreadsheet: "
 						+ e.getMessage());
 			} catch (InvalidSPDXAnalysisException e) {
-				System.out.println("Error translating the Tag file: "
-						+ e.getMessage());
 				throw new OnlineToolException("Error translating the Tag file: "
 						+ e.getMessage());
 			} catch (Exception e) {
-				System.out.print("Unexpected error converting SPDX Document: "
-						+ e.getMessage());
 				throw new OnlineToolException("Unexpected error converting SPDX Document: "
 						+ e.getMessage());
 			} finally {
@@ -229,8 +136,6 @@ public class SpreadsheetToTag {
 					try {
 						ss.close();
 					} catch (SpreadsheetException e) {
-						System.out.println("Error closing spreadsheet: "
-								+ e.getMessage());
 						throw new OnlineToolException("Error closing spreadsheet: "
 								+ e.getMessage());
 					}

--- a/src/org/spdx/tools/TagToRDF.java
+++ b/src/org/spdx/tools/TagToRDF.java
@@ -86,95 +86,12 @@ public class TagToRDF {
 				return;
 			}
 		}
-		FileInputStream spdxTagStream;
 		try {
-			spdxTagStream = new FileInputStream(args[0]);
-		} catch (FileNotFoundException ex) {
-			System.out
-					.printf("Tag-Value file %1$s does not exists.%n", args[0]);
-			return;
-		}
-
-		File spdxRDFFile = new File(args[1]);
-		if (spdxRDFFile.exists()) {
-			System.out
-					.printf("Error: File %1$s already exists - please specify a new file.%n",
-							args[1]);
-			try {
-				spdxTagStream.close();
-			} catch (IOException e) {
-				System.out.println("Warning: Unable to close input file on error.");
-			}
-			return;
-		}
-
-		try {
-			if (!spdxRDFFile.createNewFile()) {
-				System.out.println("Could not create the new SPDX RDF file "
-						+ args[1]);
-				usage();
-				try {
-					spdxTagStream.close();
-				} catch (IOException e) {
-					System.out.println("Warning: Unable to close input file on error.");
-				}
-				return;
-			}
-		} catch (IOException e1) {
-			System.out.println("Could not create the new SPDX Tag-Value file "
-					+ args[1]);
-			System.out.println("due to error " + e1.getMessage());
+			onlineFunction(args);
+		} catch (OnlineToolException e){
+			System.out.println(e.getMessage());
 			usage();
-			try {
-				spdxTagStream.close();
-			} catch (IOException e) {
-				System.out.println("Warning: Unable to close input file on error.");
-			}
 			return;
-		}
-
-		FileOutputStream out;
-		try {
-			out = new FileOutputStream(spdxRDFFile);
-		} catch (FileNotFoundException e1) {
-			System.out.println("Could not write to the new SPDX RDF file "
-					+ args[1]);
-			System.out.println("due to error " + e1.getMessage());
-			usage();
-			try {
-				spdxTagStream.close();
-			} catch (IOException e) {
-				System.out.println("Warning: Unable to close input file on error.");
-			}
-			return;
-		}
-
-		try {
-			List<String> warnings = new ArrayList<String>();
-			convertTagFileToRdf(spdxTagStream, out, outputFormat, warnings);
-			if (!warnings.isEmpty()) {
-				System.out.println("The following warnings and or verification errors were found:");
-				for (String warning:warnings) {
-					System.out.println("\t"+warning);
-				}
-			}
-		} catch (Exception e) {
-			System.err.println("Error creating SPDX Analysis: " + e);
-		} finally {
-			if (out != null) {
-				try {
-					out.close();
-				} catch (IOException e) {
-					System.out.println("Error closing RDF file: " + e.getMessage());
-				}
-			}
-			if (spdxTagStream != null) {
-				try {
-					spdxTagStream.close();
-				} catch (IOException e) {
-					System.out.println("Error closing Tag/Value file: " + e.getMessage());
-				}
-			}
 		}
 	}
 	
@@ -191,18 +108,14 @@ public class TagToRDF {
 		try {
 			spdxTagStream = new FileInputStream(args[0]);
 		} catch (FileNotFoundException ex) {
-			System.out.printf("Tag-Value file %1$s does not exists.%n", args[0]);
 			throw new OnlineToolException("Tag-Value file "+ args[0] + " does not exists.");
 		}
 		File spdxRDFFile = new File(args[1]);
 		// Output File name will be checked in the Python code for no clash, but if still found
 		if (spdxRDFFile.exists()) {
-			System.out.printf("Error: File %1$s already exists - please specify a new file.%n",
-							args[1]);
 			try {
 				spdxTagStream.close();
 			} catch (IOException e) {
-				System.out.println("Warning: Unable to close input file on error.");
 				throw new OnlineToolException("Warning: Unable to close input file on error.");
 			}
 			throw new OnlineToolException("Error: File " + args[1] +" already exists - please specify a new file.");
@@ -210,22 +123,17 @@ public class TagToRDF {
 
 		try {
 			if (!spdxRDFFile.createNewFile()) {
-				System.out.println("Could not create the new SPDX RDF file "+ args[1]);
 				try {
 					spdxTagStream.close();
 				} catch (IOException e) {
-					System.out.println("Warning: Unable to close input file on error.");
 					throw new OnlineToolException("Warning: Unable to close input file on error.");
 				}
 				throw new OnlineToolException("Could not create the new SPDX RDF file "+ args[1]);
 			}
 		} catch (IOException e1) {
-			System.out.println("Could not create the new SPDX Tag-Value file "+ args[1]);
-			System.out.println("due to error " + e1.getMessage());
 			try {
 				spdxTagStream.close();
 			} catch (IOException e) {
-				System.out.println("Warning: Unable to close input file on error.");
 				throw new OnlineToolException("Warning: Unable to close input file on error.");
 			}
 			throw new OnlineToolException("Could not create the new SPDX Tag-Value file "+ args[1] + "due to error " + e1.getMessage());
@@ -235,12 +143,9 @@ public class TagToRDF {
 		try {
 			out = new FileOutputStream(spdxRDFFile);
 		} catch (FileNotFoundException e1) {
-			System.out.println("Could not write to the new SPDX RDF file "+ args[1]);
-			System.out.println("due to error " + e1.getMessage());
 			try {
 				spdxTagStream.close();
 			} catch (IOException e) {
-				System.out.println("Warning: Unable to close input file on error.");
 				throw new OnlineToolException("Warning: Unable to close input file on error.");
 			}
 			throw new OnlineToolException("Could not write to the new SPDX RDF file "+ args[1]+ "due to error " + e1.getMessage());
@@ -255,14 +160,12 @@ public class TagToRDF {
 				}
 			}
 		} catch (Exception e) {
-			System.err.println("Error creating SPDX Analysis: " + e);
 			throw new OnlineToolException("Error creating SPDX Analysis: " + e.getMessage());
 		} finally {
 			if (out != null) {
 				try {
 					out.close();
 				} catch (IOException e) {
-					System.out.println("Error closing RDF file: " + e.getMessage());
 					throw new OnlineToolException("Error closing RDF file: " + e.getMessage());
 				}
 			}
@@ -270,7 +173,6 @@ public class TagToRDF {
 				try {
 					spdxTagStream.close();
 				} catch (IOException e) {
-					System.out.println("Error closing Tag/Value file: " + e.getMessage());
 					throw new OnlineToolException("Error closing Tag/Value file: " + e.getMessage());
 				}
 			}

--- a/src/org/spdx/tools/TagToSpreadsheet.java
+++ b/src/org/spdx/tools/TagToSpreadsheet.java
@@ -62,66 +62,12 @@ public class TagToSpreadsheet {
 			usage();
 			return;
 		}
-		FileInputStream spdxTagFile;
 		try {
-			spdxTagFile = new FileInputStream(args[0]);
-		} catch (FileNotFoundException ex) {
-			System.out
-					.printf("Tag-Value file %1$s does not exists.%n", args[0]);
+			onlineFunction(args);
+		} catch (OnlineToolException e){
+			System.out.println(e.getMessage());
+			usage();
 			return;
-		}
-		File spdxSpreadsheetFile = new File(args[1]);
-		if (spdxSpreadsheetFile.exists()) {
-			System.out
-					.println("Spreadsheet file already exists - please specify a new file.");
-			try {
-				spdxTagFile.close();
-			} catch (IOException e) {
-				System.out.println("Warning: Unable to close output SPDX tag file on error: "+e.getMessage());
-			}
-			return;
-		}
-		SpdxDocumentContainer[] result = new SpdxDocumentContainer[1];
-		try {
-			// read the tag-value constants from a file
-			Properties constants = CommonCode.getTextFromProperties("org/spdx/tag/SpdxTagValueConstants.properties");
-			NoCommentInputStream nci = new NoCommentInputStream(spdxTagFile);
-			HandBuiltParser parser = new HandBuiltParser(nci);
-			List<String> warnings = new ArrayList<String>();
-			parser.setBehavior(new BuildDocument(result, constants, warnings));
-			parser.data();
-			if (!warnings.isEmpty()) {
-				System.out.println("The following warnings and or verification errors were found:");
-				for (String warning:warnings) {
-					System.out.println("\t"+warning);
-				}
-			}
-		} catch (Exception e) {
-			System.err.println("Error creating SPDX Analysis: " + e);
-		}
-		SPDXSpreadsheet ss = null;
-		try {
-			ss = new SPDXSpreadsheet(spdxSpreadsheetFile, true, false);
-			RdfToSpreadsheet.copyRdfXmlToSpreadsheet(result[0].getSpdxDocument(), ss);
-		} catch (SpreadsheetException e) {
-			System.out.println("Error opening or writing to spreadsheet: "
-					+ e.getMessage());
-		} catch (InvalidSPDXAnalysisException e) {
-			System.out.println("Error translating the Tag file: "
-					+ e.getMessage());
-		} catch (Exception ex) {
-			System.out
-					.println("Unexpected error translating the tag-value to spreadsheet: "
-							+ ex.getMessage());
-		} finally {
-			if (ss != null) {
-				try {
-					ss.close();
-				} catch (SpreadsheetException e) {
-					System.out.println("Error closing spreadsheet: "
-							+ e.getMessage());
-				}
-			}
 		}
 	}
 	
@@ -137,17 +83,14 @@ public class TagToSpreadsheet {
 		try {
 			spdxTagFile = new FileInputStream(args[0]);
 		} catch (FileNotFoundException ex) {
-			System.out.printf("Tag-Value file %1$s does not exists.%n", args[0]);
 			throw new OnlineToolException("Tag-Value file "+ args[0]+" does not exists.");
 		}
 		File spdxSpreadsheetFile = new File(args[1]);
 		// Output File name will be checked in the Python code for no clash, but if still found
 		if (spdxSpreadsheetFile.exists()) {
-			System.out.println("Spreadsheet file already exists - please specify a new file.");
 			try {
 				spdxTagFile.close();
 			} catch (IOException e) {
-				System.out.println("Warning: Unable to close output SPDX tag file on error: "+e.getMessage());
 				throw new OnlineToolException("Warning: Unable to close output SPDX tag file on error: "+e.getMessage());
 			}
 			throw new OnlineToolException("Spreadsheet file already exists - please specify a new file name.");
@@ -178,7 +121,6 @@ public class TagToSpreadsheet {
 			throw(new OnlineToolException(e.getMessage()));
 		} catch (Exception e) {
 			// If any other exception - assume this is an RDF/XML file.
-			System.err.println("Error creating SPDX Analysis: " + e);
 			throw new OnlineToolException("Error creating SPDX Analysis: " + e);
 		}
 		SPDXSpreadsheet ss = null;
@@ -186,20 +128,16 @@ public class TagToSpreadsheet {
 			ss = new SPDXSpreadsheet(spdxSpreadsheetFile, true, false);
 			RdfToSpreadsheet.copyRdfXmlToSpreadsheet(result[0].getSpdxDocument(), ss);
 		} catch (SpreadsheetException e) {
-			System.out.println("Error opening or writing to spreadsheet: "+ e.getMessage());
 			throw new OnlineToolException("Error opening or writing to spreadsheet: "+ e.getMessage());
 		} catch (InvalidSPDXAnalysisException e) {
-			System.out.println("Error translating the Tag file: " + e.getMessage());
 			throw new OnlineToolException("Error translating the Tag file: "+ e.getMessage());
 		} catch (Exception ex) {
-			System.out.println("Unexpected error translating the tag-value to spreadsheet: "+ ex.getMessage());
 			throw new OnlineToolException("Unexpected error translating the tag-value to spreadsheet: "+ ex.getMessage());
 		} finally {
 			if (ss != null) {
 				try {
 					ss.close();
 				} catch (SpreadsheetException e) {
-					System.out.println("Error closing spreadsheet: "+ e.getMessage());
 					throw new OnlineToolException("Error closing spreadsheet: "+ e.getMessage());
 				}
 			}

--- a/src/org/spdx/tools/TagToSpreadsheet.java
+++ b/src/org/spdx/tools/TagToSpreadsheet.java
@@ -32,7 +32,11 @@ import org.spdx.spdxspreadsheet.SpreadsheetException;
 import org.spdx.tag.BuildDocument;
 import org.spdx.tag.CommonCode;
 import org.spdx.tag.HandBuiltParser;
+import org.spdx.tag.InvalidFileFormatException;
+import org.spdx.tag.InvalidSpdxTagFileException;
 import org.spdx.tag.NoCommentInputStream;
+
+import antlr.RecognitionException;
 /**
  * Translates an tag-value file to a SPDX Spreadsheet format Usage:
  * TagToSpreadsheet spdxfile.spdx spreadsheetfile.xls where spdxfile.spdx is a
@@ -157,13 +161,23 @@ public class TagToSpreadsheet {
 			HandBuiltParser parser = new HandBuiltParser(nci);
 			parser.setBehavior(new BuildDocument(result, constants, warnings));
 			parser.data();
+			if (result[0] == null) {
+				throw(new OnlineToolException("Unexpected error parsing SPDX tag document - the result is null."));
+			}
 			if (!warnings.isEmpty()) {
 				System.out.println("The following warnings and or verification errors were found:");
 				for (String warning:warnings) {
 					System.out.println("\t"+warning);
 				}
 			}
+		} catch (RecognitionException e) {
+			// error in tag value file
+			throw(new OnlineToolException(e.getMessage()));
+		} catch (InvalidFileFormatException e) {
+			// invalid spdx file format
+			throw(new OnlineToolException(e.getMessage()));
 		} catch (Exception e) {
+			// If any other exception - assume this is an RDF/XML file.
 			System.err.println("Error creating SPDX Analysis: " + e);
 			throw new OnlineToolException("Error creating SPDX Analysis: " + e);
 		}

--- a/src/org/spdx/tools/Verify.java
+++ b/src/org/spdx/tools/Verify.java
@@ -173,13 +173,7 @@ public class Verify {
 		} catch (Exception e) {
 			throw new SpdxVerificationException("Unable to parse the file: "+e.getMessage(),e);
 		}
-		List<String> verify = doc.verify();
-		List<String> retval = new ArrayList<String>();
-		if (!verify.isEmpty()) {
-			for (String verifyMsg:verify) {	
-				retval.add(verifyMsg);
-			}
-		}
+		List<String> retval = doc.verify();
 		return retval;		
 	}
 }


### PR DESCRIPTION
I have added methods somewhat similar to main methods of different tools but with fewer repetition of calling the same function from Python. Some of the methods returns warning/error message which can be displayed to the user. Also, I have removed any `System.exit` part in the method and rather thrown an OnlineToolException for every error that occur in the method. This can be caught by Jpype.
This way the JVM won't shutdown causing Django app to not shutdown inappropriately, Most of the time OnlineToolException won't be called as file exist and file check happens in python only but still I have added `throw` to them.

I hope this patch will ensure that System.exit is never encountered and the online app is run smoothly. If any of the internal methods are causing System.exit, I can later add `SecurityManager` to these methods and catch `SecurityException`. 