### PR TITLE
FsfLicenseDataParser: Fill in implementation

### DIFF
--- a/src/org/spdx/tools/LicenseRDFAGenerator.java
+++ b/src/org/spdx/tools/LicenseRDFAGenerator.java
@@ -473,7 +473,16 @@ public class LicenseRDFAGenerator {
 	 * @param license
 	 */
 	private static void addExternalMetaData(SpdxListedLicense license) {
-		license.setFsfLibre(FsfLicenseDataParser.getFsfLicenseDataParser().isSpdxLicenseFsfLibre(license.getLicenseId()));
+		Boolean libre = null;
+		try {
+			libre = FsfLicenseDataParser.getFsfLicenseDataParser().isSpdxLicenseFsfLibre(license.getLicenseId());
+		} catch (LicenseGeneratorException e) {
+			System.out.println(e.getMessage());
+			libre = null;
+		}
+		if (libre != null) {
+			license.setFsfLibre(libre);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Pull the index (mapping from SPDX IDs to FSF IDs) during initialization, and then lookup each license as needed with a separate request.

An implementation that hits `isSpdxLicenseFsfLibre` multiple times (or which wanted to extract multiple values for a single license) would be more efficient if we cached the per-license FSF response.  I've left that off for now because our only consumer is just asking for libre-ness, and only doing that once per license.

I've used a Boolean for the `isSpdxLicenseFsfLibre` to get a nullable value, so we can represent:

* “yes, the FSF marks that license ‘libre’” (`true`),
* “no, the FSF considers that license non-free” (`false`), and
* “we don't know the FSF opinion for that license” (`null`).

Related discussion in wking/fsf-api#1 and wking/fsf-api#5.

And this may be my first Java ever, so please review carefully and don't assume I know what I'm doing ;).