### PR TITLE
Moving to SLF4J and Log4J2

### DIFF
--- a/TestFiles/spdx-parser-source/org/spdx/spdxspreadsheet/AbstractSpreadsheet.java
+++ b/TestFiles/spdx-parser-source/org/spdx/spdxspreadsheet/AbstractSpreadsheet.java
@@ -23,7 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
@@ -35,7 +35,7 @@ import org.apache.poi.ss.usermodel.WorkbookFactory;
  */
 public abstract class AbstractSpreadsheet {
 
-	protected static final Logger logger = Logger.getLogger(AbstractSpreadsheet.class.getName());
+	protected static final Logger logger = LoggerFactory.getLogger(AbstractSpreadsheet.class.getName());
 
 	protected File saveFile;
 	protected Workbook workbook;

--- a/doc/org/spdx/spdxspreadsheet/AbstractSpreadsheet.html
+++ b/doc/org/spdx/spdxspreadsheet/AbstractSpreadsheet.html
@@ -125,7 +125,7 @@ extends <a href="http://docs.oracle.com/javase/6/docs/api/java/lang/Object.html?
 <th class="colLast" scope="col">Field and Description</th>
 </tr>
 <tr class="altColor">
-<td class="colFirst"><code>protected static org.apache.log4j.Logger</code></td>
+<td class="colFirst"><code>protected static org.slf4j.Logger</code></td>
 <td class="colLast"><code><strong><a href="../../../org/spdx/spdxspreadsheet/AbstractSpreadsheet.html#logger">logger</a></strong></code>&nbsp;</td>
 </tr>
 <tr class="rowColor">
@@ -220,7 +220,7 @@ extends <a href="http://docs.oracle.com/javase/6/docs/api/java/lang/Object.html?
 <ul class="blockList">
 <li class="blockList">
 <h4>logger</h4>
-<pre>protected static final&nbsp;org.apache.log4j.Logger logger</pre>
+<pre>protected static final&nbsp;org.slf4j.Logger logger</pre>
 </li>
 </ul>
 <a name="saveFile">

--- a/pom.xml
+++ b/pom.xml
@@ -156,17 +156,17 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-api</artifactId>
-		    <version>2.7</version>
+		    <version>2.10.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-core</artifactId>
-		    <version>2.7</version>
+		    <version>2.10.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j-impl</artifactId>
-		    <version>2.7</version>
+		    <version>2.10.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,19 +154,19 @@
 			<version>0.7.9</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.2</version>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-api</artifactId>
+		    <version>2.7</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.2</version>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-core</artifactId>
+		    <version>2.7</version>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.13</version>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-slf4j-impl</artifactId>
+		    <version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>

--- a/src/org/spdx/compare/MultiDocumentSpreadsheet.java
+++ b/src/org/spdx/compare/MultiDocumentSpreadsheet.java
@@ -24,9 +24,10 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.model.SpdxFile;
 import org.spdx.spdxspreadsheet.AbstractSpreadsheet;
@@ -71,7 +72,7 @@ public class MultiDocumentSpreadsheet extends AbstractSpreadsheet {
 	
 	private SpdxFileComparator fileComparator = new SpdxFileComparator();
 
-	static Logger logger = Logger.getLogger(MultiDocumentSpreadsheet.class);
+	static Logger logger = LoggerFactory.getLogger(MultiDocumentSpreadsheet.class);
 	private static final String DOCUMENT_SHEET_NAME = "Document";
 	private DocumentSheet documentSheet;
 	private static final String CREATOR_SHEET_NAME = "Creator";

--- a/src/org/spdx/compare/PackageSheet.java
+++ b/src/org/spdx/compare/PackageSheet.java
@@ -20,18 +20,18 @@ package org.spdx.compare;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxPackageVerificationCode;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxPackage;
 import org.spdx.spdxspreadsheet.AbstractSheet;
-
 /**
  * Document level fields for comparison spreadsheet
  * Column1 is the document field name, column2 indicates if all docs are equal, 
@@ -41,7 +41,7 @@ import org.spdx.spdxspreadsheet.AbstractSheet;
  */
 public class PackageSheet extends AbstractSheet {
 	
-	static final Logger logger = Logger.getLogger(PackageSheet.class);
+	static final Logger logger = LoggerFactory.getLogger(PackageSheet.class);
 	private static final int COL_WIDTH = 60;
 	protected static final int FIELD_COL = 0;
 	protected static final int EQUALS_COL = 1;

--- a/src/org/spdx/compare/SnippetSheet.java
+++ b/src/org/spdx/compare/SnippetSheet.java
@@ -19,12 +19,13 @@ package org.spdx.compare;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.model.SpdxDocument;
 import org.spdx.rdfparser.model.SpdxFile;
@@ -39,7 +40,7 @@ import org.spdx.spdxspreadsheet.AbstractSheet;
  */
 public class SnippetSheet extends AbstractSheet {
 	
-	static final Logger logger = Logger.getLogger(SnippetSheet.class);
+	static final Logger logger = LoggerFactory.getLogger(SnippetSheet.class);
 	
 	private static final int COL_WIDTH = 60;
 	protected static final int FIELD_COL = 0;

--- a/src/org/spdx/licensexml/LicenseXmlDocument.java
+++ b/src/org/spdx/licensexml/LicenseXmlDocument.java
@@ -33,7 +33,8 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.license.LicenseException;
@@ -51,7 +52,7 @@ import org.xml.sax.SAXParseException;
  *
  */
 public class LicenseXmlDocument {
-	static final Logger logger = Logger.getLogger(LicenseXmlDocument.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(LicenseXmlDocument.class.getName());
 	
 	public static final String LICENSE_XML_SCHEMA_LOCATION = "org/spdx/licensexml/ListedLicense.xsd";
 

--- a/src/org/spdx/licensexml/LicenseXmlHelper.java
+++ b/src/org/spdx/licensexml/LicenseXmlHelper.java
@@ -21,7 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.licenseTemplate.HtmlTemplateOutputHandler;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.w3c.dom.Element;
@@ -34,7 +35,7 @@ import org.w3c.dom.NodeList;
  *
  */
 public class LicenseXmlHelper implements SpdxRdfConstants {
-	static final Logger logger = Logger.getLogger(LicenseXmlHelper.class);
+	static final Logger logger = LoggerFactory.getLogger(LicenseXmlHelper.class);
 
 	private static final String INDENT_STRING = "   ";
 

--- a/src/org/spdx/licensexml/XmlLicenseProvider.java
+++ b/src/org/spdx/licensexml/XmlLicenseProvider.java
@@ -22,7 +22,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.license.ISpdxListedLicenseProvider;
 import org.spdx.rdfparser.license.LicenseException;
@@ -41,7 +42,7 @@ import com.google.common.io.Files;
  */
 public class XmlLicenseProvider implements ISpdxListedLicenseProvider {
 	
-	Logger logger = Logger.getLogger(XmlLicenseProvider.class.getName());
+	Logger logger = LoggerFactory.getLogger(XmlLicenseProvider.class.getName());
 	private List<String> warnings = new ArrayList<String>();
 	
 	class XmlLicenseIterator implements Iterator<SpdxListedLicense> {		

--- a/src/org/spdx/rdfparser/SPDXDocumentFactory.java
+++ b/src/org/spdx/rdfparser/SPDXDocumentFactory.java
@@ -24,12 +24,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Logger;
-import org.spdx.rdfparser.model.SpdxDocument;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.util.FileManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spdx.rdfparser.model.SpdxDocument;
 
 /**
  * Factory for creating an SPDX Document from a variety of different sources
@@ -39,7 +39,7 @@ import org.apache.jena.util.FileManager;
  */
 public class SPDXDocumentFactory {
 	
-	static final Logger logger = Logger.getLogger(SPDXDocumentFactory.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(SPDXDocumentFactory.class.getName());
 
 	/**
 	 * Create a new SPDX Document populating the data from the existing model

--- a/src/org/spdx/rdfparser/SPDXFile.java
+++ b/src/org/spdx/rdfparser/SPDXFile.java
@@ -19,13 +19,6 @@ package org.spdx.rdfparser;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
-import org.spdx.rdfparser.license.AnyLicenseInfo;
-import org.spdx.rdfparser.license.DuplicateExtractedLicenseIdException;
-import org.spdx.rdfparser.license.LicenseInfoFactory;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
@@ -33,6 +26,14 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.util.iterator.ExtendedIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spdx.rdfparser.license.AnyLicenseInfo;
+import org.spdx.rdfparser.license.DuplicateExtractedLicenseIdException;
+import org.spdx.rdfparser.license.LicenseInfoFactory;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 /**
  * Contains and SPDXFile object and updates the RDF model.
@@ -45,7 +46,7 @@ import org.apache.jena.util.iterator.ExtendedIterator;
 @Deprecated
 public class SPDXFile implements Comparable<SPDXFile>, Cloneable {
 	
-	static final Logger logger = Logger.getLogger(SPDXFile.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(SPDXFile.class.getName());
 	IModelContainer modelContainer;
 	private Model model = null;
 	private Resource resource = null;

--- a/src/org/spdx/rdfparser/license/AnyLicenseInfo.java
+++ b/src/org/spdx/rdfparser/license/AnyLicenseInfo.java
@@ -16,7 +16,8 @@
 */
 package org.spdx.rdfparser.license;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.model.RdfModelObject;
@@ -35,7 +36,7 @@ import org.apache.jena.rdf.model.Resource;
  */
 public abstract class AnyLicenseInfo extends RdfModelObject {
 	
-	static final Logger logger = Logger.getLogger(AnyLicenseInfo.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(AnyLicenseInfo.class.getName());
 
 	/**
 	 * Create a new LicenseInfo object where the information is copied from

--- a/src/org/spdx/rdfparser/license/LicenseInfoFactory.java
+++ b/src/org/spdx/rdfparser/license/LicenseInfoFactory.java
@@ -16,16 +16,16 @@
 */
 package org.spdx.rdfparser.license;
 
-import org.apache.log4j.Logger;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxDocumentContainer;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
-
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.Triple;
-import org.apache.jena.util.iterator.ExtendedIterator;
 
 /**
  * Factory for creating SPDXLicenseInfo objects from a Jena model
@@ -34,7 +34,7 @@ import org.apache.jena.util.iterator.ExtendedIterator;
  */
 public class LicenseInfoFactory {
 	
-	static final Logger logger = Logger.getLogger(LicenseInfoFactory.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(LicenseInfoFactory.class.getName());
 	
 	public static final String NOASSERTION_LICENSE_NAME = "NOASSERTION";
 	public static final String NONE_LICENSE_NAME = "NONE";

--- a/src/org/spdx/rdfparser/license/ListedLicenses.java
+++ b/src/org/spdx/rdfparser/license/ListedLicenses.java
@@ -29,14 +29,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-import org.spdx.rdfparser.IModelContainer;
-import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.SpdxRdfConstants;
-import org.spdx.rdfparser.model.IRdfModel;
-
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
@@ -45,6 +37,15 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.util.FileManager;
 import org.apache.jena.util.iterator.ExtendedIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spdx.rdfparser.IModelContainer;
+import org.spdx.rdfparser.InvalidSPDXAnalysisException;
+import org.spdx.rdfparser.SpdxRdfConstants;
+import org.spdx.rdfparser.model.IRdfModel;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import net.rootdev.javardfa.jena.RDFaReader.HTMLRDFaReader;
 /**
@@ -55,7 +56,7 @@ import net.rootdev.javardfa.jena.RDFaReader.HTMLRDFaReader;
 public class ListedLicenses implements IModelContainer {
 	
 	public static final String DEFAULT_LICENSE_LIST_VERSION = "2.0";
-	static final Logger logger = Logger.getLogger(ListedLicenses.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(ListedLicenses.class.getName());
 	static final String LISTED_LICENSE_ID_URL = "http://spdx.org/licenses/";
 	public static final String LISTED_LICENSE_URI_PREFIX = "http://spdx.org/licenses/";
 	private static final String LISTED_LICENSE_RDF_LOCAL_DIR = "resources" + "/" + "stdlicenses";

--- a/src/org/spdx/rdfparser/license/SpdxLicenseCsv.java
+++ b/src/org/spdx/rdfparser/license/SpdxLicenseCsv.java
@@ -24,13 +24,14 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.spdxspreadsheet.SPDXLicenseSpreadsheet.DeprecatedLicenseInfo;
 
-import au.com.bytecode.opencsv.CSVReader;
-
 import com.google.common.collect.Lists;
+
+import au.com.bytecode.opencsv.CSVReader;
 
 /**
  * A CSV file reader for SPDX Standard Licenses.
@@ -45,7 +46,7 @@ import com.google.common.collect.Lists;
 @Deprecated
 public class SpdxLicenseCsv implements ISpdxListedLicenseProvider {
 	
-	static final Logger logger = Logger.getLogger(SpdxLicenseCsv.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(SpdxLicenseCsv.class.getName());
 	public static final int LICENSE_NAME_COL = 0;
 	public static final int LICENSE_ID_COL = 1;
 	public static final int LICENSE_NOTES_COL = 3;

--- a/src/org/spdx/rdfparser/model/Annotation.java
+++ b/src/org/spdx/rdfparser/model/Annotation.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.log4j.Logger;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
@@ -31,6 +30,8 @@ import com.google.common.collect.Lists;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An Annotation is a comment on an SpdxItem by an agent.
@@ -39,7 +40,7 @@ import org.apache.jena.rdf.model.Resource;
  */
 public class Annotation extends RdfModelObject implements Comparable<Annotation> {
 	
-	static final Logger logger = Logger.getLogger(RdfModelObject.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(RdfModelObject.class.getName());
 
 	public enum AnnotationType {
 		annotationType_other,

--- a/src/org/spdx/rdfparser/model/Checksum.java
+++ b/src/org/spdx/rdfparser/model/Checksum.java
@@ -18,7 +18,8 @@ package org.spdx.rdfparser.model;
 
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.RdfParserHelper;
@@ -46,7 +47,7 @@ import org.apache.jena.util.iterator.ExtendedIterator;
  */
 public class Checksum extends RdfModelObject implements Comparable<Checksum> {
 
-	static final Logger logger = Logger.getLogger(Checksum.class);
+	static final Logger logger = LoggerFactory.getLogger(Checksum.class);
 	public enum ChecksumAlgorithm {checksumAlgorithm_sha1, checksumAlgorithm_sha256,
 		checksumAlgorithm_md5};		
 		

--- a/src/org/spdx/rdfparser/model/ExternalDocumentRef.java
+++ b/src/org/spdx/rdfparser/model/ExternalDocumentRef.java
@@ -18,7 +18,11 @@ package org.spdx.rdfparser.model;
 
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.jena.graph.Node;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
@@ -27,9 +31,6 @@ import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
-import org.apache.jena.graph.Node;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
 
 /**
  * Information about an external SPDX document reference including the checksum.  
@@ -46,7 +47,7 @@ import org.apache.jena.rdf.model.Resource;
  */
 public class ExternalDocumentRef extends RdfModelObject implements Comparable<ExternalDocumentRef> {
 
-	static final Logger logger = Logger.getLogger(RdfModelObject.class.getClass());
+	static final Logger logger = LoggerFactory.getLogger(RdfModelObject.class.getClass());
 	/**
 	 * Force a refresh for the model on every property get.  This is slower, but
 	 * will make sure that the correct value is returned if there happens to be

--- a/src/org/spdx/rdfparser/model/ExternalRef.java
+++ b/src/org/spdx/rdfparser/model/ExternalRef.java
@@ -18,7 +18,14 @@ package org.spdx.rdfparser.model;
 
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.RdfParserHelper;
@@ -27,13 +34,6 @@ import org.spdx.rdfparser.referencetype.ReferenceType;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.graph.Triple;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.util.iterator.ExtendedIterator;
-
 /**
  * An External Reference allows a Package to reference an external source of
  * additional information, metadata, enumerations, asset identifiers, or downloadable content believed to
@@ -44,7 +44,7 @@ import org.apache.jena.util.iterator.ExtendedIterator;
  */
 public class ExternalRef extends RdfModelObject implements Comparable<ExternalRef> {
 	
-	static final Logger logger = Logger.getLogger(ExternalRef.class);
+	static final Logger logger = LoggerFactory.getLogger(ExternalRef.class);
 	
 	public enum ReferenceCategory {referenceCategory_packageManager, referenceCategory_security,
 		referenceCategory_other;

--- a/src/org/spdx/rdfparser/model/Relationship.java
+++ b/src/org/spdx/rdfparser/model/Relationship.java
@@ -19,7 +19,11 @@ package org.spdx.rdfparser.model;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.apache.jena.graph.Node;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
@@ -28,9 +32,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.jena.graph.Node;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
 
 /**
  * A Relationship represents a relationship between two SpdxElements.
@@ -39,7 +40,7 @@ import org.apache.jena.rdf.model.Resource;
  */
 public class Relationship extends RdfModelObject implements Comparable<Relationship> {
 	
-	static final Logger logger = Logger.getLogger(RdfModelObject.class);
+	static final Logger logger = LoggerFactory.getLogger(RdfModelObject.class);
 	
 	public enum RelationshipType {
 		DESCRIBES("relationshipType_describes"),

--- a/src/org/spdx/rdfparser/model/SpdxElement.java
+++ b/src/org/spdx/rdfparser/model/SpdxElement.java
@@ -21,7 +21,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.jena.graph.Node;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.RdfModelHelper;
@@ -31,9 +35,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.apache.jena.graph.Node;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
 
 /**
  * An SpdxElement is any thing described in SPDX, either a document or an SpdxItem. 
@@ -50,7 +51,7 @@ import org.apache.jena.rdf.model.Resource;
  */
 public class SpdxElement extends RdfModelObject {
 	
-	static final Logger logger = Logger.getLogger(RdfModelObject.class);
+	static final Logger logger = LoggerFactory.getLogger(RdfModelObject.class);
 	
 	protected Annotation[] annotations;
 	protected String comment;

--- a/src/org/spdx/rdfparser/model/SpdxFile.java
+++ b/src/org/spdx/rdfparser/model/SpdxFile.java
@@ -20,8 +20,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
-import org.apache.log4j.Logger;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.RdfModelHelper;
@@ -30,14 +36,9 @@ import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
 import org.spdx.rdfparser.model.Checksum.ChecksumAlgorithm;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.graph.Triple;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.util.iterator.ExtendedIterator;
 
 /**
  * A File represents a named sequence of information 
@@ -47,7 +48,7 @@ import org.apache.jena.util.iterator.ExtendedIterator;
  */
 public class SpdxFile extends SpdxItem implements Comparable<SpdxFile> {
 	
-	static final Logger logger = Logger.getLogger(SpdxFile.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(SpdxFile.class.getName());
 
 	public enum FileType {fileType_application, fileType_archive,
 		fileType_audio, fileType_binary, fileType_documentation,

--- a/src/org/spdx/rdfparser/model/pointer/CompoundPointer.java
+++ b/src/org/spdx/rdfparser/model/pointer/CompoundPointer.java
@@ -19,7 +19,8 @@ package org.spdx.rdfparser.model.pointer;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
@@ -37,7 +38,7 @@ import org.apache.jena.graph.Node;
  */
 public abstract class CompoundPointer extends RdfModelObject {
 	
-	static final Logger logger=Logger.getLogger(CompoundPointer.class);
+	static final Logger logger=LoggerFactory.getLogger(CompoundPointer.class);
 	
 	protected SinglePointer startPointer;
 	

--- a/src/org/spdx/rdfparser/model/pointer/SinglePointer.java
+++ b/src/org/spdx/rdfparser/model/pointer/SinglePointer.java
@@ -19,15 +19,15 @@ package org.spdx.rdfparser.model.pointer;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.jena.graph.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.model.IRdfModel;
 import org.spdx.rdfparser.model.RdfModelObject;
 import org.spdx.rdfparser.model.SpdxElement;
-
-import org.apache.jena.graph.Node;
 
 /**
  * A pointing method made up of a unique pointer. This is an abstract single pointer that provides the necessary framework, 
@@ -39,7 +39,7 @@ import org.apache.jena.graph.Node;
  */
 public abstract class SinglePointer extends RdfModelObject implements Comparable<SinglePointer> {
 	
-	static final Logger logger = Logger.getLogger(SinglePointer.class);
+	static final Logger logger = LoggerFactory.getLogger(SinglePointer.class);
 	
 	/**
 	 * The document within which the pointer is applicable or meaningful.

--- a/src/org/spdx/rdfparser/referencetype/ListedReferenceTypes.java
+++ b/src/org/spdx/rdfparser/referencetype/ListedReferenceTypes.java
@@ -27,7 +27,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.license.LicenseInfoFactory;
@@ -42,7 +43,7 @@ import com.google.common.collect.Maps;
  */
 public class ListedReferenceTypes {
 	
-	static final Logger logger = Logger.getLogger(ListedReferenceTypes.class);
+	static final Logger logger = LoggerFactory.getLogger(ListedReferenceTypes.class);
 	private static final ReadWriteLock listedReferenceTypesModificationLock = new ReentrantReadWriteLock();
 	private static final String LISTED_REFERENCE_TYPE__RDF_LOCAL_DIR = "resources" + "/" + "listedexternaltypes";
 	private static final String LISTED_REFERENCE_TYPE_PROPERTIES_FILENAME = LISTED_REFERENCE_TYPE__RDF_LOCAL_DIR + "/" + "listedreferencetypes.properties";

--- a/src/org/spdx/rdfparser/referencetype/ReferenceType.java
+++ b/src/org/spdx/rdfparser/referencetype/ReferenceType.java
@@ -22,16 +22,16 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.jena.graph.Node;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.IModelContainer;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.model.IRdfModel;
 import org.spdx.rdfparser.model.RdfModelObject;
-
-import org.apache.jena.graph.Node;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
 
 /**
  * Type of external reference
@@ -47,7 +47,7 @@ public class ReferenceType extends RdfModelObject implements Comparable<Referenc
 	//TODO: Current implementation only uses the uri field.  Implement additional fields
 	// once the SPDX listed reference type pages are live
 	
-	static final Logger logger = Logger.getLogger(ReferenceType.class);
+	static final Logger logger = LoggerFactory.getLogger(ReferenceType.class);
 
 	String contextualExample;
 	URL documentation;

--- a/src/org/spdx/spdxspreadsheet/AbstractSpreadsheet.java
+++ b/src/org/spdx/spdxspreadsheet/AbstractSpreadsheet.java
@@ -23,10 +23,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract class for implementing file based spreadsheets.
@@ -35,7 +36,7 @@ import org.apache.poi.ss.usermodel.WorkbookFactory;
  */
 public abstract class AbstractSpreadsheet {
 
-	protected static final Logger logger = Logger.getLogger(AbstractSpreadsheet.class.getName());
+	protected static final Logger logger = LoggerFactory.getLogger(AbstractSpreadsheet.class.getName());
 	
 	protected File saveFile;
 	protected Workbook workbook;

--- a/src/org/spdx/spdxspreadsheet/DeprecatedLicenseSheet.java
+++ b/src/org/spdx/spdxspreadsheet/DeprecatedLicenseSheet.java
@@ -19,16 +19,16 @@ package org.spdx.spdxspreadsheet;
 import java.io.File;
 import java.text.SimpleDateFormat;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.licenseTemplate.LicenseTemplateRuleException;
 import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.license.SpdxListedLicense;
-
 /**
  * Sheet holding information about deprecated licenses
  * @author Gary O'Neall
@@ -36,7 +36,7 @@ import org.spdx.rdfparser.license.SpdxListedLicense;
  */
 public class DeprecatedLicenseSheet extends AbstractSheet {
 
-	static final Logger logger = Logger.getLogger(LicenseSheet.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(LicenseSheet.class.getName());
 	static final int NUM_COLS = 8;
 	static final int COL_NAME = 0;
 	static final int COL_ID = COL_NAME + 1;

--- a/src/org/spdx/spdxspreadsheet/ExternalRefsSheet.java
+++ b/src/org/spdx/spdxspreadsheet/ExternalRefsSheet.java
@@ -20,12 +20,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxDocumentContainer;
 import org.spdx.rdfparser.model.ExternalRef;
@@ -34,7 +35,6 @@ import org.spdx.rdfparser.referencetype.ListedReferenceTypes;
 import org.spdx.rdfparser.referencetype.ReferenceType;
 
 import com.google.common.collect.Lists;
-
 /**
  * Package external refs
  * @author Gary O'Neall
@@ -42,7 +42,7 @@ import com.google.common.collect.Lists;
  */
 public class ExternalRefsSheet extends AbstractSheet {
 	
-	static final Logger logger = Logger.getLogger(ExternalRefsSheet.class);
+	static final Logger logger = LoggerFactory.getLogger(ExternalRefsSheet.class);
 	
 	static final int PKG_ID_COL = 0;
 	static final int REF_CATEGORY_COL = PKG_ID_COL + 1;

--- a/src/org/spdx/spdxspreadsheet/LicenseExceptionSheet.java
+++ b/src/org/spdx/spdxspreadsheet/LicenseExceptionSheet.java
@@ -16,13 +16,13 @@
 */
 package org.spdx.spdxspreadsheet;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.license.LicenseException;
-
 /**
  * Sheet containing the License Exceptions
  * @author Gary O'Neall
@@ -30,7 +30,7 @@ import org.spdx.rdfparser.license.LicenseException;
  */
 public class LicenseExceptionSheet extends AbstractSheet {
 
-	static final Logger logger = Logger.getLogger(LicenseSheet.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(LicenseSheet.class.getName());
 	static final int NUM_COLS = 6;
 	static final int COL_NAME = 0;
 	static final int COL_ID = COL_NAME + 1;

--- a/src/org/spdx/spdxspreadsheet/LicenseSheet.java
+++ b/src/org/spdx/spdxspreadsheet/LicenseSheet.java
@@ -27,7 +27,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.text.SimpleDateFormat;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.common.usermodel.HyperlinkType;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
@@ -35,6 +34,8 @@ import org.apache.poi.ss.usermodel.Hyperlink;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.licenseTemplate.LicenseTemplateRuleException;
 import org.spdx.licenseTemplate.SpdxLicenseTemplateHelper;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
@@ -49,7 +50,7 @@ import org.spdx.rdfparser.license.SpdxListedLicense;
  */
 public class LicenseSheet extends AbstractSheet {
 	
-	static final Logger logger = Logger.getLogger(LicenseSheet.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(LicenseSheet.class.getName());
 	static final int NUM_COLS = 9;
 	static final int COL_NAME = 0;
 	static final int COL_ID = COL_NAME + 1;

--- a/src/org/spdx/spdxspreadsheet/SnippetSheet.java
+++ b/src/org/spdx/spdxspreadsheet/SnippetSheet.java
@@ -20,12 +20,13 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Logger;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SpdxDocumentContainer;
 import org.spdx.rdfparser.license.AnyLicenseInfo;
@@ -49,7 +50,7 @@ import com.google.common.collect.Maps;
  */
 public class SnippetSheet extends AbstractSheet {
 	
-	static final Logger logger = Logger.getLogger(SnippetSheet.class);
+	static final Logger logger = LoggerFactory.getLogger(SnippetSheet.class);
 	
 	static final int ID_COL = 0;
 	static final int NAME_COL = ID_COL + 1;

--- a/src/org/spdx/tag/NoCommentInputStream.java
+++ b/src/org/spdx/tag/NoCommentInputStream.java
@@ -21,7 +21,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Gary O'Neall
@@ -33,7 +34,7 @@ import org.apache.log4j.Logger;
  */
 public class NoCommentInputStream extends InputStream {
 	
-	static final Logger logger = Logger.getLogger(NoCommentInputStream.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(NoCommentInputStream.class.getName());
 	private static final CharSequence START_TEXT_TAG = "<text>";
 	private static final CharSequence END_TEXT_TAG = "</text>";
 	private static final char COMMENT_CHAR = '#';

--- a/src/org/spdx/tools/CompareSpdxDocs.java
+++ b/src/org/spdx/tools/CompareSpdxDocs.java
@@ -28,8 +28,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.log4j.Logger;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.compare.SpdxCompareException;
 import org.spdx.compare.SpdxComparer;
 import org.spdx.compare.SpdxComparer.SPDXReviewDifference;
@@ -69,7 +69,7 @@ import antlr.RecognitionException;
  *
  */
 public class CompareSpdxDocs {
-	static final Logger logger = Logger.getLogger(CompareSpdxDocs.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(CompareSpdxDocs.class.getName());
 
 	static final int MIN_ARGS = 2;
 	static final int MAX_ARGS = 3;

--- a/src/org/spdx/tools/LicenseListPublisher.java
+++ b/src/org/spdx/tools/LicenseListPublisher.java
@@ -23,7 +23,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
@@ -31,7 +30,8 @@ import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /**
  * Publishes a new version of the license list.
  * 
@@ -67,7 +67,7 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
  */
 public class LicenseListPublisher {
 	
-	static final Logger logger = Logger.getLogger(LicenseListPublisher.class);
+	static final Logger logger = LoggerFactory.getLogger(LicenseListPublisher.class);
 	
 	static final int ERROR_STATUS = 1;
 	private static final String LICENSE_XML_URI = "https://github.com/goneall/license-list-XML.git";

--- a/src/org/spdx/tools/RdfToTag.java
+++ b/src/org/spdx/tools/RdfToTag.java
@@ -38,7 +38,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SPDXDocumentFactory;
 import org.spdx.rdfparser.model.SpdxDocument;
@@ -54,7 +55,7 @@ import org.spdx.tag.CommonCode;
 public class RdfToTag {
 	static final int MIN_ARGS = 2;
 	static final int MAX_ARGS = 2;
-	static final Logger logger = Logger.getLogger(RdfToTag.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(RdfToTag.class.getName());
 
 	/**
 	 * @param args

--- a/src/org/spdx/tools/SpreadsheetToRDF.java
+++ b/src/org/spdx/tools/SpreadsheetToRDF.java
@@ -27,7 +27,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SPDXCreatorInformation;
 import org.spdx.rdfparser.SPDXReview;
@@ -70,7 +71,7 @@ import com.google.common.collect.Maps;
  */
 public class SpreadsheetToRDF {
 
-	static final Logger logger = Logger.getLogger(SpreadsheetToRDF.class.getName());
+	static final Logger logger = LoggerFactory.getLogger(SpreadsheetToRDF.class.getName());
 	static final int MIN_ARGS = 2;
 	static final int MAX_ARGS = 2;
 	


### PR DESCRIPTION
Because Log4J is end-of-lifed and our current code is tightly coupled, I updated our dependencies to use SLF4J with Log4J2. This not only updates the logging framework to the latest version, but prevents us from having to change the code should we need to change the logging framework again.