### PR TITLE
Update license RDFa Generator to use the latest XML schema

### DIFF
--- a/Test/org/spdx/licensexml/LicenseXmlDocumentTest.java
+++ b/Test/org/spdx/licensexml/LicenseXmlDocumentTest.java
@@ -60,7 +60,7 @@ public class LicenseXmlDocumentTest {
 			"\n   <<var;name=\"bullet\";original=\"1.\";match=\".{0,20}\">>\n   List item 1\n   <<var;name=\"bullet\";original=\"2.\";match=\".{0,20}\">>\n   List item 2\n" +
 			"Last Paragraph <<var;name=\"alttest\";original=\"Alternate Text\";match=\".+\">> Non matching line.<<beginOptional>> Optional text<<endOptional>>";
 
-	private static final String TEST_DEP_LICENSE_COMMENT = "Test dep note; Notes second line";
+	private static final String TEST_DEP_LICENSE_COMMENT = "Test dep note";
 	private static final String TEST_DEP_LICENSE_ID = "test-dep";
 	private static final String TEST_DEP_LICENSE_TEXT = "Test Copyright dep\nparagraph 1d" +
 			"\n   1.d\n   List item 1d\n   2.d\n   List item 2d\n" +

--- a/TestFiles/AGPL-3.0-only.xml
+++ b/TestFiles/AGPL-3.0-only.xml
@@ -21,6 +21,7 @@
     <notes>
       This version was released: 19 November 2007
     </notes>
+    <text>
     <titleText>
       <p>
         GNU AFFERO GENERAL PUBLIC LICENSE<br></br>
@@ -844,5 +845,6 @@
 	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
+  </text>
   </license>
 </SPDXLicenseCollection>

--- a/TestFiles/test-license.xml
+++ b/TestFiles/test-license.xml
@@ -1,4 +1,4 @@
-<SPDXLicenseCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.spdx.org/license https://raw.githubusercontent.com/spdx/license-list-XML/schemadev/schema/ListedLicense.xsd" xmlns="http://www.spdx.org/license">
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
 	<license name="Test License" licenseId="test-id" isOsiApproved="true">
 		<notes>Test note</notes>
 		<crossRefs>
@@ -9,6 +9,7 @@
     Test header<optional>optional</optional>
     <alt name="h1test" match=".+">var</alt>
   </standardLicenseHeader>
+     <text>
 		<copyrightText>
 			<p>Test Copyright</p>
 		</copyrightText>
@@ -27,6 +28,7 @@
           <alt name="alttest" match=".+">Alternate Text</alt>Non matching line.
           <optional>Optional text</optional>
 		</p>
+	  </text>
 	</license>
 	<license name="Test Deprecated License" licenseId="test-dep" isOsiApproved="false" isDeprecated="true" deprecatedVersion="2.2">
 		<notes>Test dep note</notes>
@@ -37,7 +39,7 @@
 		<standardLicenseHeader> 
     		Test header dep
   		</standardLicenseHeader>
-  		<notes>Notes second line</notes>
+  		<text>
 		<copyrightText>
 			<p>Test Copyright dep</p>
 		</copyrightText>
@@ -56,6 +58,7 @@
           <alt name="alttestd" match=".+">Alternate Text dep</alt>Non matching line dep.
           <optional>Optional text dep</optional>
 		</p>
+		</text>
 	</license>
 	<exception name="Test Exception" licenseId="test-ex">
 		<notes>Test note exception</notes>
@@ -63,6 +66,7 @@
 			<crossRef>http://test/url1e</crossRef>
 			<crossRef>http://test/url2e</crossRef>
 		</crossRefs>
+		<text>
 		<copyrightText>
 			<p>Test Copyrighte</p>
 		</copyrightText>
@@ -81,5 +85,6 @@
           <alt name="altteste" match=".+">Alternate Text exc</alt>Non matching line. e
           <optional>Optional text exc</optional>
 		</p>
+		</text>
 	</exception>
 </SPDXLicenseCollection>

--- a/src/org/spdx/licensexml/LicenseXmlDocument.java
+++ b/src/org/spdx/licensexml/LicenseXmlDocument.java
@@ -147,7 +147,12 @@ public class LicenseXmlDocument {
 		String id = licenseElement.getAttribute(SpdxRdfConstants.LICENSEXML_ATTRIBUTE_ID);
 		boolean deprecated = licenseElement.hasAttribute(SpdxRdfConstants.LICENSEXML_ATTRIBUTE_DEPRECATED) &&
 				"true".equals(licenseElement.getAttribute(SpdxRdfConstants.LICENSEXML_ATTRIBUTE_DEPRECATED).toLowerCase());
-		String text = LicenseXmlHelper.getLicenseText(licenseElement);
+		NodeList textNodes = licenseElement.getElementsByTagName(SpdxRdfConstants.LICENSEXML_ELEMENT_TEXT);
+		if (textNodes.getLength() != 1) {
+			throw new LicenseXmlException("Invalid number of text elements.  Expected 1 - found "+textNodes.getLength());
+		}
+		Element textElement = (Element)textNodes.item(0);
+		String text = LicenseXmlHelper.getLicenseText(textElement);
 		NodeList notes = licenseElement.getElementsByTagName(SpdxRdfConstants.LICENSEXML_ELEMENT_NOTES);
 		String comment = null;
 		if (notes.getLength() > 0) {
@@ -171,22 +176,22 @@ public class LicenseXmlDocument {
 			StringBuilder sbText = new StringBuilder();
 			StringBuilder sbTemplate = new StringBuilder();
 			StringBuilder sbHtml = new StringBuilder();
-			sbText.append(LicenseXmlHelper.getHeaderText(headerNodes.item(0)));
-			sbTemplate.append(LicenseXmlHelper.getHeaderTemplate(headerNodes.item(0)));
-			sbHtml.append(LicenseXmlHelper.getHeaderTextHtml(headerNodes.item(0)));
+			sbText.append(LicenseXmlHelper.getHeaderText((Element)headerNodes.item(0)));
+			sbTemplate.append(LicenseXmlHelper.getHeaderTemplate((Element)headerNodes.item(0)));
+			sbHtml.append(LicenseXmlHelper.getHeaderTextHtml((Element)headerNodes.item(0)));
 			for (int i = 1; i < headerNodes.getLength(); i++) {
 				sbText.append('\n');
-				sbText.append(LicenseXmlHelper.getHeaderText(headerNodes.item(i)));
+				sbText.append(LicenseXmlHelper.getHeaderText((Element)headerNodes.item(i)));
 				sbTemplate.append('\n');
-				sbTemplate.append(LicenseXmlHelper.getHeaderTemplate(headerNodes.item(i)));
+				sbTemplate.append(LicenseXmlHelper.getHeaderTemplate((Element)headerNodes.item(i)));
 				sbHtml.append("<br />\n");
-				sbHtml.append(LicenseXmlHelper.getHeaderTextHtml(headerNodes.item(i)));
+				sbHtml.append(LicenseXmlHelper.getHeaderTextHtml((Element)headerNodes.item(i)));
 			}
 			licenseHeader = sbText.toString();
 			licenseHeaderTemplate = sbTemplate.toString();
 			licenseHeaderTemplateHtml = sbHtml.toString();
 		}
-		String template = LicenseXmlHelper.getLicenseTemplate(licenseElement);
+		String template = LicenseXmlHelper.getLicenseTemplate(textElement);
 		boolean osiApproved;
 		if (licenseElement.hasAttribute(SpdxRdfConstants.LICENSEXML_ATTRIBUTE_OSI_APPROVED)) {
 			osiApproved = "true".equals(licenseElement.getAttribute(SpdxRdfConstants.LICENSEXML_ATTRIBUTE_OSI_APPROVED).toLowerCase());
@@ -199,7 +204,7 @@ public class LicenseXmlDocument {
 		} else {
 			fsfLibre = false;
 		}
-		String licenseHtml = LicenseXmlHelper.getLicenseTextHtml(licenseElement);
+		String licenseHtml = LicenseXmlHelper.getLicenseTextHtml(textElement);
 		SpdxListedLicense retval = new SpdxListedLicense(name, id, text, sourceUrls, comment, licenseHeader, 
 				template, licenseHeaderTemplate, osiApproved, fsfLibre, licenseHtml, licenseHeaderTemplateHtml);
 		retval.setDeprecated(deprecated);
@@ -224,9 +229,14 @@ public class LicenseXmlDocument {
 	private LicenseException getException(Element exceptionElement) throws LicenseXmlException {
 		String name = exceptionElement.getAttribute(SpdxRdfConstants.LICENSEXML_ATTRIBUTE_NAME);
 		String id = exceptionElement.getAttribute(SpdxRdfConstants.LICENSEXML_ATTRIBUTE_ID);
-		String text = LicenseXmlHelper.getLicenseText(exceptionElement);
-		String template = LicenseXmlHelper.getLicenseTemplate(exceptionElement);
-		String html = LicenseXmlHelper.getLicenseTextHtml(exceptionElement);
+		NodeList textNodes = exceptionElement.getElementsByTagName(SpdxRdfConstants.LICENSEXML_ELEMENT_TEXT);
+		if (textNodes.getLength() != 1) {
+			throw new LicenseXmlException("Invalid number of text elements.  Expected 1 - found "+textNodes.getLength());
+		}
+		Element textElement = (Element)textNodes.item(0);
+		String text = LicenseXmlHelper.getLicenseText(textElement);
+		String template = LicenseXmlHelper.getLicenseTemplate(textElement);
+		String html = LicenseXmlHelper.getLicenseTextHtml(textElement);
 		NodeList notes = exceptionElement.getElementsByTagName(SpdxRdfConstants.LICENSEXML_ELEMENT_NOTES);
 		String comment = null;
 		if (notes.getLength() > 0) {

--- a/src/org/spdx/licensexml/LicenseXmlHelper.java
+++ b/src/org/spdx/licensexml/LicenseXmlHelper.java
@@ -42,80 +42,32 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	private static final String BULLET_ALT_MATCH = ".{0,20}";
 
 	private static final String BULLET_ALT_NAME = "bullet";
-
-	/**
-	 * Tags that do not require any processing - the text for the children will be included
-	 */
-	static HashSet<String> LICENSE_AND_EXCEPTION_SKIPPED_TAGS = new HashSet<String>();
-	static {
-		LICENSE_AND_EXCEPTION_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_CROSS_REF);
-		LICENSE_AND_EXCEPTION_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_CROSS_REFS);
-		LICENSE_AND_EXCEPTION_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_NOTES);
-		LICENSE_AND_EXCEPTION_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER);
-	}
 	
+	/**
+	 * The text under these elements are included without modification
+	 */
 	static HashSet<String> LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS = new HashSet<String>();
 	static {
 		LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_COPYRIGHT_TEXT);
-		//LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_TITLE_TEXT);
 		LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_ITEM);
-		LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_LICENSE);
-		LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_EXCEPTION);
-		//LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_BULLET);
+		LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_TEXT);
 	}
 	
-	static HashSet<String> NOTES_SKIPPED_TAGS = new HashSet<String>();
-	static {
-		NOTES_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_CROSS_REF);
-		NOTES_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_CROSS_REFS);
-		NOTES_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER);
-	}
-	
-	static HashSet<String> NOTES_UNPROCESSED_TAGS = new HashSet<String>();
-	static {
-		NOTES_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_COPYRIGHT_TEXT);
-		NOTES_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_TITLE_TEXT);
-		NOTES_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_ITEM);
-		NOTES_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_LICENSE);
-		NOTES_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_EXCEPTION);
-		NOTES_UNPROCESSED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_NOTES);
-		NOTES_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_BULLET);
-	}
-	
-	static HashSet<String> HEADER_SKIPPED_TAGS = new HashSet<String>();
-	static {
-		HEADER_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_CROSS_REF);
-		HEADER_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_CROSS_REFS);
-		HEADER_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_NOTES);
-	}
-	
+	/**
+	 * The text under these elements are included without modification
+	 */
 	static HashSet<String> HEADER_UNPROCESSED_TAGS = new HashSet<String>();
 	static {
 		HEADER_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_COPYRIGHT_TEXT);
 		HEADER_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_TITLE_TEXT);
 		HEADER_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_ITEM);
-		HEADER_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_LICENSE);
-		HEADER_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_EXCEPTION);
 		HEADER_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_BULLET);
-		HEADER_UNPROCESSED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER);
+		HEADER_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER);
 	}
 	
-	static HashSet<String> EXAMPLE_SKIPPED_TAGS = new HashSet<String>();
+	static HashSet<String> NOTES_UNPROCESSED_TAGS = new HashSet<String>();
 	static {
-		EXAMPLE_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_CROSS_REF);
-		EXAMPLE_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_CROSS_REFS);
-		EXAMPLE_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_NOTES);
-		EXAMPLE_SKIPPED_TAGS.add(SpdxRdfConstants.LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER);
-	}
-	
-	static HashSet<String> EXAMPLE_UNPROCESSED_TAGS = new HashSet<String>();
-	static {
-		EXAMPLE_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_COPYRIGHT_TEXT);
-		EXAMPLE_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_TITLE_TEXT);
-		EXAMPLE_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_ITEM);
-		EXAMPLE_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_LICENSE);
-		EXAMPLE_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_EXCEPTION);
-		EXAMPLE_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_BULLET);
+		NOTES_UNPROCESSED_TAGS.add(LICENSEXML_ELEMENT_NOTES);
 	}
 	
 	static HashSet<String> FLOW_CONTROL_ELEMENTS = new HashSet<String>();
@@ -135,13 +87,12 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @param sb Stringbuilder to append the text to
 	 * @param indentCount number of indentations (e.g. number of embedded lists)
 	 * @param unprocessedTags Tags that do not require any process - text of the children of that tag should just be appended.
-	 * @param skippedTags Tags that should not be included
 	 * @param includeHtmlTags if true, include HTML tags for creating an HTML fragment including the formatting from the original XML element
 	 * @return
 	 * @throws LicenseXmlException 
 	 */
 	private static void appendNodeText(Node node, boolean useTemplateFormat, StringBuilder sb, int indentCount, HashSet<String> unprocessedTags,
-			HashSet<String> skippedTags, boolean includeHtmlTags) throws LicenseXmlException {
+			boolean includeHtmlTags) throws LicenseXmlException {
 		if (node.getNodeType() == Node.TEXT_NODE) {
 			if (includeHtmlTags) {
 				sb.append(StringEscapeUtils.escapeHtml4(fixUpText(node.getNodeValue())));
@@ -152,7 +103,7 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 			Element element = (Element)node;
 			String tagName = element.getTagName();
 			if (LICENSEXML_ELEMENT_LIST.equals(tagName)) {
-				appendListElements(element, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+				appendListElements(element, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 			} else if (LICENSEXML_ELEMENT_ALT.equals(tagName)) {
 				if (!element.hasAttribute(LICENSEXML_ATTRIBUTE_ALT_NAME)) {
 					throw(new LicenseXmlException("Missing name attribute for variable text"));
@@ -162,40 +113,40 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 					throw(new LicenseXmlException("Missing match attribute for variable text"));
 				}
 				String match = element.getAttribute(LICENSEXML_ATTRIBUTE_ALT_MATCH);
-				appendAltText(element, altName, match, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+				appendAltText(element, altName, match, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 			} else if (LICENSEXML_ELEMENT_OPTIONAL.equals(tagName)) {
-				appendOptionalText(element, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+				appendOptionalText(element, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 			} else if (LICENSEXML_ELEMENT_BREAK.equals(tagName)) {
 				if (includeHtmlTags) {
 					sb.append("<br>");
 				}
 				addNewline(sb, indentCount);
-				appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+				appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 			} else if (LICENSEXML_ELEMENT_PARAGRAPH.equals(tagName)) {
 				if (includeHtmlTags) {
 					appendParagraphTag(sb, indentCount);
 				} else if (sb.length() > 1) {
 					addNewline(sb, indentCount);
 				}
-				appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+				appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 				if (includeHtmlTags) {
 					sb.append("</p>\n");
 				}
 			} else if (LICENSEXML_ELEMENT_TITLE_TEXT.equals(tagName)) {
 				if (!inALtBlock(element)) {
-				appendOptionalText(element, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+				appendOptionalText(element, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 				} else {
-					appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+					appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 				}
 			} else if (LICENSEXML_ELEMENT_BULLET.equals(tagName)) {
 				if (!inALtBlock(element)) {
-					appendAltText(element, BULLET_ALT_NAME, BULLET_ALT_MATCH, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+					appendAltText(element, BULLET_ALT_NAME, BULLET_ALT_MATCH, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 				} else {
-					appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+					appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
 				}
 			} else if (unprocessedTags.contains(tagName)) {
-				appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
-			} else if (!skippedTags.contains(tagName)) {
+				appendElementChildrenText(element, useTemplateFormat, sb, indentCount, unprocessedTags, includeHtmlTags);
+			} else {
 				throw(new LicenseXmlException("Unknown license element tag name: "+tagName));
 			}
 		}
@@ -278,17 +229,16 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @param sb Stringbuilder to append the text to
 	 * @param indentCount number of indentations (e.g. number of embedded lists)
 	 * @param unprocessedTags Tags that do not require any process - text of the children of that tag should just be appended.
-	 * @param skippedTags Tags that should not be included
 	 * @param includeHtmlTags if true, include HTML tags for creating an HTML fragment including the formatting from the original XML element
 	 * @throws LicenseXmlException 
 	 */
 	private static void appendElementChildrenText(Element element,
 			boolean useTemplateFormat, StringBuilder sb, int indentCount, HashSet<String> unprocessedTags,
-			HashSet<String> skippedTags, boolean includeHtmlTags) throws LicenseXmlException {
+			boolean includeHtmlTags) throws LicenseXmlException {
 		NodeList licenseChildNodes = element.getChildNodes();
 		for (int i = 0; i < licenseChildNodes.getLength(); i++) {
 			appendNodeText(licenseChildNodes.item(i),useTemplateFormat, sb, indentCount, 
-					unprocessedTags, skippedTags, includeHtmlTags);
+					unprocessedTags, includeHtmlTags);
 		}	
 	}
 
@@ -312,16 +262,15 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @param sb Stringbuilder to append the text to
 	 * @param indentCount number of indentations (e.g. number of embedded lists)
 	 * @param unprocessedTags Tags that do not require any process - text of the children of that tag should just be appended.
-	 * @param skippedTags Tags that should not be included
 	 * @param includeHtmlTags if true, include HTML tags for creating an HTML fragment including the formatting from the original XML element
 	 * @throws LicenseXmlException 
 	 */
 	private static void appendOptionalText(Element element,
 			boolean useTemplateFormat, StringBuilder sb, int indentCount, HashSet<String> unprocessedTags,
-			HashSet<String> skippedTags, boolean includeHtmlTags) throws LicenseXmlException {
+			boolean includeHtmlTags) throws LicenseXmlException {
 		StringBuilder childSb = new StringBuilder();
 		if (element.hasChildNodes()) {
-			appendElementChildrenText(element, useTemplateFormat, childSb, indentCount, unprocessedTags, skippedTags, includeHtmlTags);
+			appendElementChildrenText(element, useTemplateFormat, childSb, indentCount, unprocessedTags, includeHtmlTags);
 		} else {
 			childSb.append(element.getTextContent());
 		}
@@ -390,17 +339,16 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @param sb Stringbuilder to append the text to
 	 * @param indentCount number of indentations (e.g. number of embedded lists)
 	 * @param unprocessedTags Tags that do not require any process - text of the children of that tag should just be appended.
-	 * @param skippedTags Tags that should not be included
 	 * @param includeHtmlTags if true, include HTML tags for creating an HTML fragment including the formatting from the original XML element
 	 * @throws LicenseXmlException 
 	 */
 	private static void appendAltText(Element element, String altName, String match,
 			boolean useTemplateFormat, StringBuilder sb, int indentCount, HashSet<String> unprocessedTags,
-			HashSet<String> skippedTags, boolean includeHtmlTags) throws LicenseXmlException {
+			boolean includeHtmlTags) throws LicenseXmlException {
 		StringBuilder originalSb = new StringBuilder();
 		if (element.hasChildNodes()) {
 			appendElementChildrenText(element, useTemplateFormat, originalSb, indentCount, 
-					unprocessedTags, skippedTags, includeHtmlTags);
+					unprocessedTags, includeHtmlTags);
 		} else {
 			originalSb.append(element.getTextContent());
 		}
@@ -447,13 +395,12 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @param sb
 	 * @param indentCount Number of indentations for the text
 	 * @param unprocessedTags Tags that do not require any process - text of the children of that tag should just be appended.
-	 * @param skippedTags Tags that should not be included
 	 * @param includeHtmlTags if true, include HTML tags for creating an HTML fragment including the formatting from the original XML element
 	 * @throws LicenseXmlException 
 	 */
 	private static void appendListElements(Element element,
 			boolean useTemplateFormat, StringBuilder sb, int indentCount, HashSet<String> unprocessedTags,
-			HashSet<String> skippedTags, boolean includeHtmlTags) throws LicenseXmlException {
+			boolean includeHtmlTags) throws LicenseXmlException {
 		if (!LICENSEXML_ELEMENT_LIST.equals(element.getTagName())) {
 			throw(new LicenseXmlException("Invalid list element tag - expected 'list', found '"+element.getTagName()+"'"));
 		}
@@ -467,16 +414,16 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 				if (LICENSEXML_ELEMENT_ITEM.equals(listItem.getTagName())) {
 					if (includeHtmlTags) {
 						sb.append("\n<li>");
-						appendNodeText(listItem, useTemplateFormat, sb, indentCount + 1, unprocessedTags, skippedTags, includeHtmlTags);
+						appendNodeText(listItem, useTemplateFormat, sb, indentCount + 1, unprocessedTags, includeHtmlTags);
 						sb.append("</li>");
 					} else {
 						addNewline(sb, indentCount+1);
-						appendNodeText(listItem, useTemplateFormat, sb, indentCount + 1, unprocessedTags, skippedTags, includeHtmlTags);
+						appendNodeText(listItem, useTemplateFormat, sb, indentCount + 1, unprocessedTags, includeHtmlTags);
 					}
 					
 				} else if (LICENSEXML_ELEMENT_LIST.equals(listItem.getTagName())) {
 					appendListElements(listItem, useTemplateFormat, sb, indentCount+1,
-							unprocessedTags, skippedTags, includeHtmlTags);
+							unprocessedTags, includeHtmlTags);
 				} else {
 					throw(new LicenseXmlException("Expected only list item tags ('item') or lists ('list') in a list, found "+listItem.getTagName()));
 				}
@@ -496,9 +443,11 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @throws LicenseXmlException 
 	 */
 	public static String getLicenseTemplate(Element licenseElement) throws LicenseXmlException {
+		if (!LICENSEXML_ELEMENT_TEXT.equals(licenseElement.getTagName())) {
+			throw(new LicenseXmlException("Invalid element tag name - expected '"+LICENSEXML_ELEMENT_TEXT+"'"+licenseElement.getTagName()+"'"));
+		}
 		StringBuilder sb = new StringBuilder();
-		appendNodeText(licenseElement, true, sb, 0, LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS, 
-				LICENSE_AND_EXCEPTION_SKIPPED_TAGS, false);
+		appendNodeText(licenseElement, true, sb, 0, LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS, false);
 		return fixUpText(sb.toString());
 	}
 	
@@ -509,8 +458,11 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @throws LicenseXmlException
 	 */
 	public static String getNoteText(Element licenseElement) throws LicenseXmlException {
+		if (!LICENSEXML_ELEMENT_NOTES.equals(licenseElement.getTagName())) {
+			throw(new LicenseXmlException("Invalid element tag name - expected '"+LICENSEXML_ELEMENT_NOTES+"'"+licenseElement.getTagName()+"'"));
+		}
 		StringBuilder sb = new StringBuilder();
-		appendNodeText(licenseElement, false, sb, 0, NOTES_UNPROCESSED_TAGS, NOTES_SKIPPED_TAGS, false);
+		appendNodeText(licenseElement, false, sb, 0, NOTES_UNPROCESSED_TAGS, false);
 		return sb.toString();
 	}
 
@@ -521,9 +473,11 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @throws LicenseXmlException 
 	 */
 	public static String getLicenseText(Element licenseElement) throws LicenseXmlException {
+		if (!LICENSEXML_ELEMENT_TEXT.equals(licenseElement.getTagName())) {
+			throw(new LicenseXmlException("Invalid element tag name - expected '"+LICENSEXML_ELEMENT_TEXT+"'"+licenseElement.getTagName()+"'"));
+		}
 		StringBuilder sb = new StringBuilder();
-		appendNodeText(licenseElement, false, sb, 0, LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS, 
-				LICENSE_AND_EXCEPTION_SKIPPED_TAGS, false);
+		appendNodeText(licenseElement, false, sb, 0, LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS, false);
 		return fixUpText(sb.toString());
 	}
 	
@@ -561,46 +515,44 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	}
 
 	/**
-	 * @param headerNode
+	 * @param headerElement
 	 * @return header text where headerNode is the root element
 	 * @throws LicenseXmlException 
 	 */
-	public static Object getHeaderText(Node headerNode) throws LicenseXmlException {
+	public static Object getHeaderText(Element headerElement) throws LicenseXmlException {
+		if (!LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER.equals(headerElement.getTagName())) {
+			throw(new LicenseXmlException("Invalid element tag name - expected '"+LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER+"'"+headerElement.getTagName()+"'"));
+		}
 		StringBuilder sb = new StringBuilder();
-		appendNodeText(headerNode, false, sb, 0, HEADER_UNPROCESSED_TAGS, HEADER_SKIPPED_TAGS, false);
+		appendNodeText(headerElement, false, sb, 0, HEADER_UNPROCESSED_TAGS, false);
 		return fixUpText(sb.toString());
 	}
 	
 	/**
-	 * @param headerNode
+	 * @param headerElement
 	 * @return header template where headerNode is the root element
 	 * @throws LicenseXmlException 
 	 */
-	public static Object getHeaderTemplate(Node headerNode) throws LicenseXmlException {
+	public static Object getHeaderTemplate(Element headerElement) throws LicenseXmlException {
+		if (!LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER.equals(headerElement.getTagName())) {
+			throw(new LicenseXmlException("Invalid element tag name - expected '"+LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER+"'"+headerElement.getTagName()+"'"));
+		}
 		StringBuilder sb = new StringBuilder();
-		appendNodeText(headerNode, true, sb, 0, HEADER_UNPROCESSED_TAGS, HEADER_SKIPPED_TAGS, false);
+		appendNodeText(headerElement, true, sb, 0, HEADER_UNPROCESSED_TAGS, false);
 		return fixUpText(sb.toString());
 	}
 	
 	/**
-	 * @param headerNode
+	 * @param headerElement
 	 * @return header html fragment where headerNode is the root element
 	 * @throws LicenseXmlException 
 	 */
-	public static Object getHeaderTextHtml(Node headerNode) throws LicenseXmlException {
+	public static Object getHeaderTextHtml(Element headerElement) throws LicenseXmlException {
+		if (!LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER.equals(headerElement.getTagName())) {
+			throw(new LicenseXmlException("Invalid element tag name - expected '"+LICENSEXML_ELEMENT_STANDARD_LICENSE_HEADER+"'"+headerElement.getTagName()+"'"));
+		}
 		StringBuilder sb = new StringBuilder();
-		appendNodeText(headerNode, false, sb, 0, HEADER_UNPROCESSED_TAGS, HEADER_SKIPPED_TAGS, true);
-		return fixUpText(sb.toString());
-	}
-
-	/**
-	 * @param exampleElement
-	 * @return Example text where exampleElement is the root element
-	 * @throws LicenseXmlException 
-	 */
-	public static String getExampleText(Element exampleElement) throws LicenseXmlException {
-		StringBuilder sb = new StringBuilder();
-		appendNodeText(exampleElement, false, sb, 0, EXAMPLE_UNPROCESSED_TAGS, EXAMPLE_SKIPPED_TAGS, false);
+		appendNodeText(headerElement, false, sb, 0, HEADER_UNPROCESSED_TAGS, true);
 		return fixUpText(sb.toString());
 	}
 
@@ -619,8 +571,11 @@ public class LicenseXmlHelper implements SpdxRdfConstants {
 	 * @throws LicenseXmlException 
 	 */
 	public static String getLicenseTextHtml(Element licenseElement) throws LicenseXmlException {
+		if (!LICENSEXML_ELEMENT_TEXT.equals(licenseElement.getTagName())) {
+			throw(new LicenseXmlException("Invalid element tag name - expected '"+LICENSEXML_ELEMENT_TEXT+"'"+licenseElement.getTagName()+"'"));
+		}
 		StringBuilder sb = new StringBuilder();
-		appendNodeText(licenseElement, false, sb, 0, LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS, LICENSE_AND_EXCEPTION_SKIPPED_TAGS, true);
+		appendNodeText(licenseElement, false, sb, 0, LICENSE_AND_EXCEPTION_UNPROCESSED_TAGS, true);
 		return fixUpText(sb.toString());
 	}
 

--- a/src/org/spdx/licensexml/ListedLicense.xsd
+++ b/src/org/spdx/licensexml/ListedLicense.xsd
@@ -17,43 +17,28 @@
 		</choice>
 	</complexType>
 	<complexType name="ExceptionType" mixed="true">
-		<choice minOccurs="1" maxOccurs="unbounded">
+		<all>
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="titleText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="copyrightText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="bullet" type="string"/>
-			<element name="list" type="tns:listType"/>
-			<element name="p" type="tns:formattedAltTextType"/>
-			<element name="optional" type="tns:optionalType"/>
-			<element name="alt" type="tns:altType"/>
-			<element name="br" type="tns:emptyType"/>
-		</choice>
-		<attribute name="licenseId" type="string"/>
+			<element name="text" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+		</all>
+		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isDeprecated" type="boolean"/>
-		<attribute name="name" type="string"/>
+		<attribute name="name" type="string" use="required" />
 		<attribute name="listVersionAdded" type="string"/>
 		<attribute name="deprecatedVersion" type="string"/>
 	</complexType>
 	<complexType name="LicenseType" mixed="true">
-		<choice minOccurs="1" maxOccurs="unbounded">
+		<all>
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
 			<element name="standardLicenseHeader" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="titleText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="copyrightText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="bullet" type="string"/>
-			<element name="list" type="tns:listType"/>
-			<element name="p" type="tns:formattedAltTextType"/>
-			<element name="optional" type="tns:optionalType"/>
-			<element name="alt" type="tns:altType"/>
-			<element name="br" type="tns:emptyType"/>
-		</choice>
-		<attribute name="licenseId" type="string"/>
+			<element name="text" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+		</all>
+		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isOsiApproved" type="boolean"/>
-		<attribute name="isFsfLibre" type="boolean"/>
 		<attribute name="isDeprecated" type="boolean"/>
-		<attribute name="name" type="string"/>
+		<attribute name="name" type="string" use="required" />
 		<attribute name="listVersionAdded" type="string"/>
 		<attribute name="deprecatedVersion" type="string"/>
 	</complexType>
@@ -64,8 +49,8 @@
 	</complexType>
 	<complexType name="altType" mixed="true">
 		<group ref="tns:formattedFixedTextGroup" minOccurs="0" maxOccurs="unbounded"/>
-		<attribute name="name" type="string"/>
-		<attribute name="match" type="string"/>
+		<attribute name="name" type="string" use="required" />
+		<attribute name="match" type="string" use="required" />
 	</complexType>
 	<complexType name="optionalType" mixed="true">
 		<group ref="tns:formattedAltTextGroup" minOccurs="0" maxOccurs="unbounded"/>

--- a/src/org/spdx/rdfparser/SpdxRdfConstants.java
+++ b/src/org/spdx/rdfparser/SpdxRdfConstants.java
@@ -308,5 +308,6 @@ public interface SpdxRdfConstants {
 	public static final String LICENSEXML_ATTRIBUTE_ALT_NAME = "name";
 	public static final String LICENSEXML_ATTRIBUTE_ALT_MATCH = "match";
 	public static final String LICENSEXML_ELEMENT_BREAK = "br";
+	public static final String LICENSEXML_ELEMENT_TEXT = "text";
 	
 }


### PR DESCRIPTION
Handles text element correctly. 

Remove a bunch of kludgy code based on the previous schema.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>