### PR TITLE
Update tools to use the new JSON-LD version of the FSF-Free API's

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,18 @@
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
 			<version>4.7.1.201706071930-r</version>
+			<exclusions>
+		   <!--Conflict with Jena - use a later version -->
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+				</exclusion>
+    		</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/resources/licenses-full.json
+++ b/resources/licenses-full.json
@@ -1,1636 +1,2396 @@
 {
-  "ACDL": {
-    "name": "Apple's Common Documentation License, Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://fedoraproject.org/wiki/Licensing/Common_Documentation_License"
-  },
-  "AGPLv1.0": {
-    "identifiers": {
-      "spdx": "AGPL-1.0"
-    },
-    "name": "Affero General Public License version 1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:AGPLv1"
-  },
-  "AGPLv3.0": {
-    "identifiers": {
-      "spdx": "AGPL-3.0"
-    },
-    "name": "GNU Affero General Public License (AGPL) version 3",
-    "tags": [
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/agpl.html"
-  },
-  "ATTPublicLicense": {
-    "name": "AT&T Public License",
-    "tags": [
-      "non-free"
-    ]
-  },
-  "AcademicFreeLicense1.1": {
-    "identifiers": {
-      "spdx": "AFL-1.1"
-    },
-    "name": "Academic Free License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:AFLv3"
-  },
-  "AcademicFreeLicense1.2": {
-    "identifiers": {
-      "spdx": "AFL-1.2"
-    },
-    "name": "Academic Free License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:AFLv3"
-  },
-  "AcademicFreeLicense2.0": {
-    "identifiers": {
-      "spdx": "AFL-2.0"
-    },
-    "name": "Academic Free License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:AFLv3"
-  },
-  "AcademicFreeLicense2.1": {
-    "identifiers": {
-      "spdx": "AFL-2.1"
-    },
-    "name": "Academic Free License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:AFLv3"
-  },
-  "AcademicFreeLicense3.0": {
-    "identifiers": {
-      "spdx": "AFL-3.0"
-    },
-    "name": "Academic Free License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:AFLv3"
-  },
-  "Aladdin": {
-    "identifiers": {
-      "spdx": "Aladdin"
-    },
-    "name": "Aladdin Free Public License",
-    "tags": [
-      "non-free"
-    ]
-  },
-  "Arphic": {
-    "name": "Arphic Public License",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://ftp.gnu.org/gnu/non-gnu/chinese-fonts-truetype/LICENSE"
-  },
-  "ArtisticLicense": {
-    "identifiers": {
-      "spdx": "Artistic-1.0"
-    },
-    "name": "Artistic License 1.0",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Artistic_v1.0"
-  },
-  "ArtisticLicense2": {
-    "identifiers": {
-      "spdx": "Artistic-2.0"
-    },
-    "name": "Artistic License 2.0",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ArtisticLicense2.0"
-  },
-  "BerkeleyDB": {
-    "identifiers": {
-      "spdx": "Sleepycat"
-    },
-    "name": "Berkeley Database License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Sleepycat"
-  },
-  "CC-BY-NC-1.0": {
-    "identifiers": {
-      "spdx": "CC-BY-NC-1.0"
-    },
-    "name": "Creative Commons Nocommercial, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-NC-2.0": {
-    "identifiers": {
-      "spdx": "CC-BY-NC-2.0"
-    },
-    "name": "Creative Commons Nocommercial, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-NC-2.5": {
-    "identifiers": {
-      "spdx": "CC-BY-NC-2.5"
-    },
-    "name": "Creative Commons Nocommercial, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-NC-3.0": {
-    "identifiers": {
-      "spdx": "CC-BY-NC-3.0"
-    },
-    "name": "Creative Commons Nocommercial, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-NC-4.0": {
-    "identifiers": {
-      "spdx": "CC-BY-NC-4.0"
-    },
-    "name": "Creative Commons Nocommercial, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-ND-1.0": {
-    "identifiers": {
-      "spdx": "CC-BY-ND-1.0"
-    },
-    "name": "Creative Commons Noderivatives, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-ND-2.0": {
-    "identifiers": {
-      "spdx": "CC-BY-ND-2.0"
-    },
-    "name": "Creative Commons Noderivatives, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-ND-2.5": {
-    "identifiers": {
-      "spdx": "CC-BY-ND-2.5"
-    },
-    "name": "Creative Commons Noderivatives, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-ND-3.0": {
-    "identifiers": {
-      "spdx": "CC-BY-ND-3.0"
-    },
-    "name": "Creative Commons Noderivatives, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC-BY-ND-4.0": {
-    "identifiers": {
-      "spdx": "CC-BY-ND-4.0"
-    },
-    "name": "Creative Commons Noderivatives, any version",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://www.gnu.org/licenses/license-list.html"
-  },
-  "CC0": {
-    "identifiers": {
-      "spdx": "CC0-1.0"
-    },
-    "name": "CC0",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:CC0"
-  },
-  "CDDL": {
-    "identifiers": {
-      "spdx": "CDDL-1.0"
-    },
-    "name": "Common Development and Distribution License (CDDL), version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:CDDLv1.0"
-  },
-  "CPAL": {
-    "identifiers": {
-      "spdx": "CPAL-1.0"
-    },
-    "name": "Common Public Attribution License 1.0 (CPAL)",
-    "tags": [
-      "libre"
-    ],
-    "uri": "https://www.socialtext.net/open/cpal_license_in_wikitext"
-  },
-  "CeCILL": {
-    "identifiers": {
-      "spdx": "CECILL-2.0"
-    },
-    "name": "CeCILL version 2",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "https://directory.fsf.org/wiki/License:CeCILLv2"
-  },
-  "CeCILL-B": {
-    "identifiers": {
-      "spdx": "CECILL-B"
-    },
-    "name": "CeCILL-B version 1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "https://directory.fsf.org/wiki/License:CeCILL-B"
-  },
-  "CeCILL-C": {
-    "identifiers": {
-      "spdx": "CECILL-C"
-    },
-    "name": "CeCILL-C version 1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "https://directory.fsf.org/wiki/License:CeCILL-C"
-  },
-  "ClarifiedArtistic": {
-    "identifiers": {
-      "spdx": "ClArtistic"
-    },
-    "name": "Clarified Artistic License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/"
-  },
-  "CommonPublicLicense10": {
-    "identifiers": {
-      "spdx": "CPL-1.0"
-    },
-    "name": "Common Public License Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:CPLv1.0"
-  },
-  "Condor": {
-    "identifiers": {
-      "spdx": "Condor-1.1"
-    },
-    "name": "Condor Public License",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:Condor1.1"
-  },
-  "CryptixGeneralLicense": {
-    "name": "Cryptix General License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:CryptixGL"
-  },
-  "DOR": {
-    "name": "CNRI Digital Object Repository License Agreement",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://dorepository.org/download.html"
-  },
-  "ECL2.0": {
-    "identifiers": {
-      "spdx": "ECL-2.0"
-    },
-    "name": "Educational Community License 2.0",
-    "tags": [
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ECL2.0"
-  },
-  "EPL": {
-    "identifiers": {
-      "spdx": "EPL-1.0"
-    },
-    "name": "Eclipse Public License Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:EPLv1.0"
-  },
-  "EPL2": {
-    "identifiers": {
-      "spdx": "EPL-2.0"
-    },
-    "name": "Eclipse Public License Version 2.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:EPLv2.0"
-  },
-  "EUDataGrid": {
-    "identifiers": {
-      "spdx": "EUDatagrid"
-    },
-    "name": "EU DataGrid Software License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:EUDataGrid"
-  },
-  "EUPL": {
-    "identifiers": {
-      "spdx": "EUPL-1.1"
-    },
-    "name": "European Union Public License (EUPL) version 1.1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:EUPLv1.1"
-  },
-  "Eiffel": {
-    "identifiers": {
-      "spdx": "EFL-2.0"
-    },
-    "name": "Eiffel Forum License, version 2",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:EFLv2"
-  },
-  "Expat": {
-    "identifiers": {
-      "spdx": "MIT"
-    },
-    "name": "Expat License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Expat"
-  },
-  "FDLv1.1": {
-    "identifiers": {
-      "spdx": "GFDL-1.1"
-    },
-    "name": "GNU Free Documentation License",
-    "tags": [
-      "fdl-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/fdl.html"
-  },
-  "FDLv1.2": {
-    "identifiers": {
-      "spdx": "GFDL-1.2"
-    },
-    "name": "GNU Free Documentation License",
-    "tags": [
-      "fdl-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/fdl.html"
-  },
-  "FDLv1.3": {
-    "identifiers": {
-      "spdx": "GFDL-1.3"
-    },
-    "name": "GNU Free Documentation License",
-    "tags": [
-      "fdl-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/fdl.html"
-  },
-  "FreeArt": {
-    "name": "Free Art License",
-    "tags": [
-      "libre"
-    ],
-    "uri": "https://directory.fsf.org/wiki/License:Free-Art-L-v1.3"
-  },
-  "FreeBSD": {
-    "identifiers": {
-      "spdx": "BSD-2-Clause-FreeBSD"
-    },
-    "name": "FreeBSD license",
-    "tags": [
-      "fdl-compatible",
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:FreeBSD"
-  },
-  "GNUAllPermissive": {
-    "identifiers": {
-      "spdx": "FSFAP"
-    },
-    "name": "GNU All-Permissive License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
-  },
-  "GNUGPLv3": {
-    "identifiers": {
-      "spdx": "GPL-3.0"
-    },
-    "name": "GNU General Public License (GPL) version 3",
-    "tags": [
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/gpl.html"
-  },
-  "GNUVerbatim": {
-    "name": "GNU Verbatim Copying License",
-    "tags": [
-      "viewpoint"
-    ],
-    "uri": "https://www.gnu.org/licenses/licenses.html#VerbatimCopying"
-  },
-  "GPL-PA": {
-    "name": "GPL for Computer Programs of the Public Administration",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:GPL-PA"
-  },
-  "GPLFonts": {
-    "name": "GNU General Public License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/gpl.html"
-  },
-  "GPLOther": {
-    "name": "GNU General Public License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/gpl.html"
-  },
-  "GPLv2": {
-    "identifiers": {
-      "spdx": "GPL-2.0"
-    },
-    "name": "GNU General Public License (GPL) version 2",
-    "tags": [
-      "gpl-2-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
-  },
-  "HESSLA": {
-    "name": "Hacktivismo Enhanced-Source Software License Agreement",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://www.hacktivismo.com/about/hessla.php"
-  },
-  "HPND": {
-    "identifiers": {
-      "spdx": "HPND"
-    },
-    "name": "Historical Permission Notice and Disclaimer",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Historical_Permission_Notice_and_Disclaimer"
-  },
-  "IBMPL": {
-    "identifiers": {
-      "spdx": "IPL-1.0"
-    },
-    "name": "IBM Public License, Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:IBMPLv1.0"
-  },
-  "IPAFONT": {
-    "identifiers": {
-      "spdx": "IPA"
-    },
-    "name": "IPA\n    Font License",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:IPA_Font_License"
-  },
-  "ISC": {
-    "identifiers": {
-      "spdx": "ISC"
-    },
-    "name": "ISC License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ISC"
-  },
-  "JSON": {
-    "identifiers": {
-      "spdx": "JSON"
-    },
-    "name": "The JSON License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:JSON"
-  },
-  "Jahia": {
-    "name": "Jahia Community Source License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://web.archive.org/web/20050317081359/http://www.jahia.org/jahia/page145.html"
-  },
-  "LGPLv2.1": {
-    "identifiers": {
-      "spdx": "LGPL-2.1"
-    },
-    "name": "GNU Lesser General Public License (LGPL) version 2.1",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
-  },
-  "LGPLv3": {
-    "identifiers": {
-      "spdx": "LGPL-3.0"
-    },
-    "name": "GNU Lesser General Public License (LGPL) version 3",
-    "tags": [
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/lgpl.html"
-  },
-  "LPPL-1.2": {
-    "identifiers": {
-      "spdx": "LPPL-1.2"
-    },
-    "name": "LaTeX Project Public License 1.2",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:LPPLv1.2"
-  },
-  "LPPL-1.3a": {
-    "identifiers": {
-      "spdx": "LPPL-1.3a"
-    },
-    "name": "LaTeX Project Public License 1.3a",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:LPPLv1.3a"
-  },
-  "Lha": {
-    "name": "License of Lha",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Lha"
-  },
-  "MPL": {
-    "identifiers": {
-      "spdx": "MPL-1.1"
-    },
-    "name": "Mozilla Public License (MPL) version 1.1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:MPLv1.1"
-  },
-  "MPL-2.0": {
-    "identifiers": {
-      "spdx": "MPL-2.0"
-    },
-    "name": "Mozilla Public\n       License (MPL) version 2.0",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:MPLv2.0"
-  },
-  "ModifiedBSD": {
-    "identifiers": {
-      "spdx": "BSD-3-Clause"
-    },
-    "name": "Modified BSD license",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:BSD_3Clause"
-  },
-  "Ms-SS": {
-    "name": "Microsoft's Shared Source CLI, C#, and Jscript License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Ms-SS"
-  },
-  "NASA": {
-    "identifiers": {
-      "spdx": "NASA-1.3"
-    },
-    "name": "NASA Open Source Agreement",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:NASA-OSA_v1.3"
-  },
-  "NCSA": {
-    "identifiers": {
-      "spdx": "NCSA"
-    },
-    "name": "NCSA/University of Illinois Open Source License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:IllinoisNCSA"
-  },
-  "NOSL": {
-    "identifiers": {
-      "spdx": "NOSL"
-    },
-    "name": "Netizen Open Source License (NOSL), Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:NOSLv1.0"
-  },
-  "NPL-1.0": {
-    "identifiers": {
-      "spdx": "NPL-1.0"
-    },
-    "name": "Netscape Public License (NPL)",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:NPLv1.1"
-  },
-  "NPL-1.1": {
-    "identifiers": {
-      "spdx": "NPL-1.1"
-    },
-    "name": "Netscape Public License (NPL)",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:NPLv1.1"
-  },
-  "NoLicense": {
-    "identifiers": {
-      "spdx": "NONE"
-    },
-    "name": "No license",
-    "tags": [
-      "non-free"
-    ]
-  },
-  "Nokia": {
-    "identifiers": {
-      "spdx": "Nokia"
-    },
-    "name": "Nokia Open Source License",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:NokOSv1.0a"
-  },
-  "ODbl": {
-    "identifiers": {
-      "spdx": "ODbL-1.0"
-    },
-    "name": "Open Database license",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ODbl"
-  },
-  "OSL-1.0": {
-    "identifiers": {
-      "spdx": "OSL-1.0"
-    },
-    "name": "Open Software License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OSLv3.0"
-  },
-  "OSL-1.1": {
-    "identifiers": {
-      "spdx": "OSL-1.1"
-    },
-    "name": "Open Software License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OSLv3.0"
-  },
-  "OSL-2.0": {
-    "identifiers": {
-      "spdx": "OSL-2.0"
-    },
-    "name": "Open Software License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OSLv3.0"
-  },
-  "OSL-2.1": {
-    "identifiers": {
-      "spdx": "OSL-2.1"
-    },
-    "name": "Open Software License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OSLv3.0"
-  },
-  "OSL-3.0": {
-    "identifiers": {
-      "spdx": "OSL-3.0"
-    },
-    "name": "Open Software License, all versions through 3.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OSLv3.0"
-  },
-  "OculusRift": {
-    "name": "Oculus Rift SDK License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Oculus_VR_Rift_SDK_License"
-  },
-  "OpenContentL": {
-    "name": "Open Content License, Version 1.0",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "https://web.archive.org/web/19981206111937/http://www.opencontent.org/opl.shtml"
-  },
-  "OpenPublicL": {
-    "identifiers": {
-      "spdx": "OPL-1.0"
-    },
-    "name": "Open Public License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OpenPLv1.0"
-  },
-  "OpenPublicationL": {
-    "name": "Open Publication License, Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://opencontent.org/openpub/"
-  },
-  "OpenSSL": {
-    "identifiers": {
-      "spdx": "OpenSSL"
-    },
-    "name": "OpenSSL license",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OpenSSL"
-  },
-  "OriginalBSD": {
-    "identifiers": {
-      "spdx": "BSD-4-Clause"
-    },
-    "name": "Original BSD license",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:BSD_4Clause"
-  },
-  "PHP-3.01": {
-    "identifiers": {
-      "spdx": "PHP-3.01"
-    },
-    "name": "PHP License, Version 3.01",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:PHPv3.01"
-  },
-  "PINE": {
-    "name": "License of PINE",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:PINE"
-  },
-  "PPL": {
-    "name": "Peer-Production License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:PPL"
-  },
-  "PerlLicense": {
-    "name": "License of Perl 5 and below",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ]
-  },
-  "Phorum": {
-    "name": "Phorum License, Version 2.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Phorum2.0"
-  },
-  "Plan9": {
-    "name": "Old Plan 9 license",
-    "tags": [
-      "non-free"
-    ]
-  },
-  "PublicDomain": {
-    "name": "Public Domain",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:PublicDomain"
-  },
-  "Python": {
-    "name": "License of Python 2.0.1, 2.1.1, and newer versions",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:Python2.0.1"
-  },
-  "Python1.6a2": {
-    "name": "License of Python 1.6a2 and earlier versions",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:Python1.6a2"
-  },
-  "Python1.6b1": {
-    "name": "License of Python 1.6b1 through 2.0 and 2.1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Python1.6b1"
-  },
-  "Python2.0": {
-    "identifiers": {
-      "spdx": "Python-2.0"
-    },
-    "name": "License of Python 1.6b1 through 2.0 and 2.1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Python1.6b1"
-  },
-  "Python2.1": {
-    "name": "License of Python 1.6b1 through 2.0 and 2.1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Python1.6b1"
-  },
-  "QPL": {
-    "identifiers": {
-      "spdx": "QPL-1.0"
-    },
-    "name": "Q Public License (QPL), Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:QPLv1.0"
-  },
-  "RPL": {
-    "name": "Reciprocal Public License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ReciprocalPLv1.3"
-  },
-  "RPSL": {
-    "identifiers": {
-      "spdx": "RPSL-1.0"
-    },
-    "name": "RealNetworks Public Source License (RPSL), Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:RPSLv1.0"
-  },
-  "Ruby": {
-    "identifiers": {
-      "spdx": "Ruby"
-    },
-    "name": "License of Ruby",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Ruby"
-  },
-  "SGIFreeB": {
-    "identifiers": {
-      "spdx": "SGI-B-2.0"
-    },
-    "name": "SGI Free Software License B, version 2.0",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:SGIFreeBv2"
-  },
-  "SILOFL": {
-    "identifiers": {
-      "spdx": "OFL-1.1"
-    },
-    "name": "SIL Open Font License 1.1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/SIL_Open_Font_License_1.1"
-  },
-  "SISSL": {
-    "name": "Sun Industry Standards Source License 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://www.openoffice.org/licenses/sissl_license.html"
-  },
-  "SML": {
-    "name": "Simple Machines License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:SimpleM"
-  },
-  "SPL": {
-    "identifiers": {
-      "spdx": "SPL-1.0"
-    },
-    "name": "Sun Public License",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:SPLv1.0"
-  },
-  "Scilab": {
-    "name": "Scilab license",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Scilab-old"
-  },
-  "Scratch": {
-    "name": "Scratch 1.4 license",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Scratch"
-  },
-  "Squeak": {
-    "name": "Old Squeak license",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Squeak-old"
-  },
-  "StandardMLofNJ": {
-    "identifiers": {
-      "spdx": "SMLNJ"
-    },
-    "name": "Standard ML of New Jersey Copyright License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:StandardMLofNJ"
-  },
-  "SunCommunitySourceLicense": {
-    "name": "Sun Community Source License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:SunCSLv2.8"
-  },
-  "SunSolarisSourceCode": {
-    "name": "Sun Solaris Source Code (Foundation Release) License, Version 1.1",
-    "tags": [
-      "non-free"
-    ]
-  },
-  "SystemC-3.0": {
-    "name": "SystemC",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://www.accellera.org/about/policies/SystemC_Open_Source_License.pdf"
-  },
-  "Truecrypt-3.0": {
-    "name": "Truecrypt license 3.0",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:TrueCrypt"
-  },
-  "UPL": {
-    "identifiers": {
-      "spdx": "UPL-1.0"
-    },
-    "name": "Universal Permissive License (UPL)",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Universal_Permissive_License"
-  },
-  "Unicode": {
-    "name": "Unicode, Inc. License Agreement for Data Files and Software",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Unicode"
-  },
-  "Unlicense": {
-    "identifiers": {
-      "spdx": "Unlicense"
-    },
-    "name": "The Unlicense",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:TheUnlicense"
-  },
-  "UtahPublicLicense": {
-    "name": "University of Utah Public License",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://www.cs.utah.edu/~gk/teem/txt/LICENSE.txt"
-  },
-  "Vim": {
-    "identifiers": {
-      "spdx": "Vim"
-    },
-    "name": "License of Vim, Version 6.1 or later",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Vim7.2"
-  },
-  "W3C": {
-    "identifiers": {
-      "spdx": "W3C"
-    },
-    "name": "W3C Software Notice and License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:W3C_31Dec2002"
-  },
-  "WTFPL": {
-    "identifiers": {
-      "spdx": "WTFPL"
-    },
-    "name": "WTFPL, Version 2",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://sam.zoy.org/wtfpl/COPYING"
-  },
-  "Watcom": {
-    "identifiers": {
-      "spdx": "Watcom-1.0"
-    },
-    "name": "Sybase Open Watcom Public License version 1.0",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "ftp://ftp.openwatcom.org/install/license.txt"
-  },
-  "WebM": {
-    "name": "License of WebM",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:WebM"
-  },
-  "X11License": {
-    "identifiers": {
-      "spdx": "X11"
-    },
-    "name": "X11 License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:X11"
-  },
-  "XFree861.1License": {
-    "identifiers": {
-      "spdx": "XFree86-1.1"
-    },
-    "name": "XFree86 1.1 License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:XFree86_1.1"
-  },
-  "YaST": {
-    "name": "YaST License",
-    "tags": [
-      "non-free"
-    ]
-  },
-  "Yahoo": {
-    "identifiers": {
-      "spdx": "YPL-1.1"
-    },
-    "name": "Yahoo! Public License 1.1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:YPLv1.1"
-  },
-  "ZLib": {
-    "identifiers": {
-      "spdx": "Zlib"
-    },
-    "name": "License of ZLib",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Zlib"
-  },
-  "Zend": {
-    "identifiers": {
-      "spdx": "Zend-2.0"
-    },
-    "name": "Zend License, Version 2.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ZELv2.0"
-  },
-  "Zimbra": {
-    "identifiers": {
-      "spdx": "Zimbra-1.3"
-    },
-    "name": "Zimbra Public License 1.3",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://www.zimbra.com/license/zimbra-public-license-1-3.html"
-  },
-  "Zope": {
-    "name": "Zope Public License version 1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://web.archive.org/web/20000816090640/http://www.zope.org/Resources/ZPL"
-  },
-  "Zope2.0": {
-    "identifiers": {
-      "spdx": "ZPL-2.0"
-    },
-    "name": "Zope Public License, versions 2.0 and 2.1",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:ZopePLv2.1"
-  },
-  "Zope2.1": {
-    "identifiers": {
-      "spdx": "ZPL-2.1"
-    },
-    "name": "Zope Public License, versions 2.0 and 2.1",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:ZopePLv2.1"
-  },
-  "apache1": {
-    "identifiers": {
-      "spdx": "Apache-1.0"
-    },
-    "name": "Apache License, Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Apache1.0"
-  },
-  "apache1.1": {
-    "identifiers": {
-      "spdx": "Apache-1.1"
-    },
-    "name": "Apache License, Version 1.1",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Apache1.1"
-  },
-  "apache2": {
-    "identifiers": {
-      "spdx": "Apache-2.0"
-    },
-    "name": "Apache License, Version 2.0",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Apache2.0"
-  },
-  "apsl1": {
-    "identifiers": {
-      "spdx": "APSL-1.0"
-    },
-    "name": "Apple Public Source License (APSL), version 1.x",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:APSLv1.x"
-  },
-  "apsl2": {
-    "identifiers": {
-      "spdx": "APSL-2.0"
-    },
-    "name": "Apple Public Source License (APSL), version 2",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:APSLv2.0"
-  },
-  "bittorrent": {
-    "identifiers": {
-      "spdx": "BitTorrent-1.1"
-    },
-    "name": "BitTorrent Open Source License",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
-  },
-  "boost": {
-    "identifiers": {
-      "spdx": "BSL-1.0"
-    },
-    "name": "Boost Software License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Boost1.0"
-  },
-  "ccby": {
-    "identifiers": {
-      "spdx": "CC-BY-4.0"
-    },
-    "name": "Creative Commons Attribution 4.0 license",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://creativecommons.org/licenses/by/4.0/legalcode"
-  },
-  "ccbynd": {
-    "name": "Creative Commons Attribution-NoDerivs 4.0 license\n    (a.k.a. CC",
-    "tags": [
-      "viewpoint"
-    ],
-    "uri": "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
-  },
-  "ccbysa": {
-    "identifiers": {
-      "spdx": "CC-BY-SA-4.0"
-    },
-    "name": "Creative Commons Attribution-Sharealike 4.0 license",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://creativecommons.org/licenses/by-sa/4.0/legalcode"
-  },
-  "clearbsd": {
-    "identifiers": {
-      "spdx": "BSD-3-Clause-Clear"
-    },
-    "name": "The Clear BSD License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ClearBSD"
-  },
-  "cpol": {
-    "identifiers": {
-      "spdx": "CPOL-1.02"
-    },
-    "name": "Code Project Open License, version 1.02",
-    "tags": [
-      "non-free"
-    ]
-  },
-  "dsl": {
-    "name": "Design Science License (DSL)",
-    "tags": [
-      "libre"
-    ],
-    "uri": "https://www.gnu.org/licenses/dsl.html"
-  },
-  "eCos11": {
-    "identifiers": {
-      "spdx": "RHeCos-1.1"
-    },
-    "name": "eCos Public License, version 1.1",
-    "tags": [
-      "non-free"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ECosPLv1.1"
-  },
-  "eCos2.0": {
-    "identifiers": {
-      "spdx": "GPL-2.0+ WITH eCos-exception-2.0"
-    },
-    "name": "eCos license version 2.0",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:ECos2.0"
-  },
-  "ecfonts": {
-    "name": "License\n       of the ec fonts for LaTeX",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:LaTeX_ecfonts"
-  },
-  "freetype": {
-    "identifiers": {
-      "spdx": "FTL"
-    },
-    "name": "Freetype Project License",
-    "tags": [
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:FreeType"
-  },
-  "gnuplot": {
-    "identifiers": {
-      "spdx": "gnuplot"
-    },
-    "name": "Gnuplot license",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Gnuplot"
-  },
-  "iMatix": {
-    "identifiers": {
-      "spdx": "iMatix"
-    },
-    "name": "License of the iMatix Standard Function Library",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:SFL"
-  },
-  "ijg": {
-    "identifiers": {
-      "spdx": "IJG"
-    },
-    "name": "Independent JPEG Group License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki?title=License:JPEG"
-  },
-  "imlib": {
-    "identifiers": {
-      "spdx": "Imlib2"
-    },
-    "name": "License of imlib2",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Imlib2"
-  },
-  "informal": {
-    "name": "Informal license",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ]
-  },
-  "intel": {
-    "identifiers": {
-      "spdx": "Intel"
-    },
-    "name": "Intel Open Source License",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:IntelACPI"
-  },
-  "josl": {
-    "name": "Jabber Open Source License, Version 1.0",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:JabberOSLv1.0"
-  },
-  "ksh93": {
-    "name": "Old license of ksh93",
-    "tags": [
-      "non-free"
-    ]
-  },
-  "lucent102": {
-    "identifiers": {
-      "spdx": "LPL-1.02"
-    },
-    "name": "Lucent Public License Version 1.02 (Plan 9 license)",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:LucentPLv1.02"
-  },
-  "ms-pl": {
-    "identifiers": {
-      "spdx": "MS-PL"
-    },
-    "name": "Microsoft Public License (Ms-PL)",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:MsPL"
-  },
-  "ms-rl": {
-    "identifiers": {
-      "spdx": "MS-RL"
-    },
-    "name": "Microsoft Reciprocal License (Ms-RL)",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:MsRL"
-  },
-  "newOpenLDAP": {
-    "identifiers": {
-      "spdx": "OLDAP-2.7"
-    },
-    "name": "OpenLDAP License, Version 2.7",
-    "tags": [
-      "gpl-2-compatible",
-      "gpl-3-compatible",
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OpenLDAPv2.7"
-  },
-  "oldOpenLDAP": {
-    "identifiers": {
-      "spdx": "OLDAP-2.3"
-    },
-    "name": "Old OpenLDAP License, Version 2.3",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:OpenLDAPv2.3"
-  },
-  "xinetd": {
-    "identifiers": {
-      "spdx": "xinetd"
-    },
-    "name": "License of xinetd",
-    "tags": [
-      "libre"
-    ],
-    "uri": "http://directory.fsf.org/wiki/License:Xinetd"
+  "@context": "https://wking.github.io/fsf-api/schema/licenses.jsonld",
+  "licenses": {
+    "ACDL": {
+      "name": "Apple's Common Documentation License, Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ACDL",
+        "http://fedoraproject.org/wiki/Licensing/Common_Documentation_License"
+      ]
+    },
+    "AGPLv1.0": {
+      "identifiers": {
+        "spdx": [
+          "AGPL-1.0"
+        ]
+      },
+      "name": "Affero General Public License version 1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#AGPLv1.0",
+        "http://directory.fsf.org/wiki/License:AGPLv1"
+      ]
+    },
+    "AGPLv3.0": {
+      "identifiers": {
+        "spdx": [
+          "AGPL-3.0-or-later",
+          "AGPL-3.0-only",
+          "AGPL-3.0"
+        ]
+      },
+      "name": "GNU Affero General Public License (AGPL) version 3",
+      "tags": [
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#AGPLv3.0",
+        "https://www.gnu.org/licenses/agpl.html"
+      ]
+    },
+    "ATTPublicLicense": {
+      "name": "AT&T Public License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ATTPublicLicense"
+      ]
+    },
+    "AcademicFreeLicense1.1": {
+      "identifiers": {
+        "spdx": [
+          "AFL-1.1"
+        ]
+      },
+      "name": "Academic Free License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
+        "http://directory.fsf.org/wiki/License:AFLv3"
+      ]
+    },
+    "AcademicFreeLicense1.2": {
+      "identifiers": {
+        "spdx": [
+          "AFL-1.2"
+        ]
+      },
+      "name": "Academic Free License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
+        "http://directory.fsf.org/wiki/License:AFLv3"
+      ]
+    },
+    "AcademicFreeLicense2.0": {
+      "identifiers": {
+        "spdx": [
+          "AFL-2.0"
+        ]
+      },
+      "name": "Academic Free License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
+        "http://directory.fsf.org/wiki/License:AFLv3"
+      ]
+    },
+    "AcademicFreeLicense2.1": {
+      "identifiers": {
+        "spdx": [
+          "AFL-2.1"
+        ]
+      },
+      "name": "Academic Free License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
+        "http://directory.fsf.org/wiki/License:AFLv3"
+      ]
+    },
+    "AcademicFreeLicense3.0": {
+      "identifiers": {
+        "spdx": [
+          "AFL-3.0"
+        ]
+      },
+      "name": "Academic Free License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#AcademicFreeLicense",
+        "http://directory.fsf.org/wiki/License:AFLv3"
+      ]
+    },
+    "Aladdin": {
+      "identifiers": {
+        "spdx": [
+          "Aladdin"
+        ]
+      },
+      "name": "Aladdin Free Public License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Aladdin"
+      ]
+    },
+    "Arphic": {
+      "name": "Arphic Public License",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Arphic",
+        "http://ftp.gnu.org/gnu/non-gnu/chinese-fonts-truetype/LICENSE"
+      ]
+    },
+    "ArtisticLicense": {
+      "identifiers": {
+        "spdx": [
+          "Artistic-1.0"
+        ]
+      },
+      "name": "Artistic License 1.0",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ArtisticLicense",
+        "http://directory.fsf.org/wiki/License:Artistic_v1.0"
+      ]
+    },
+    "ArtisticLicense2": {
+      "identifiers": {
+        "spdx": [
+          "Artistic-2.0"
+        ]
+      },
+      "name": "Artistic License 2.0",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ArtisticLicense2",
+        "http://directory.fsf.org/wiki/License:ArtisticLicense2.0"
+      ]
+    },
+    "BerkeleyDB": {
+      "identifiers": {
+        "spdx": [
+          "Sleepycat"
+        ]
+      },
+      "name": "Berkeley Database License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#BerkeleyDB",
+        "http://directory.fsf.org/wiki/License:Sleepycat"
+      ]
+    },
+    "CC-BY-NC-1.0": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-NC-1.0"
+        ]
+      },
+      "name": "Creative Commons Nocommercial, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-NC",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-NC-2.0": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-NC-2.0"
+        ]
+      },
+      "name": "Creative Commons Nocommercial, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-NC",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-NC-2.5": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-NC-2.5"
+        ]
+      },
+      "name": "Creative Commons Nocommercial, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-NC",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-NC-3.0": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-NC-3.0"
+        ]
+      },
+      "name": "Creative Commons Nocommercial, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-NC",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-NC-4.0": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-NC-4.0"
+        ]
+      },
+      "name": "Creative Commons Nocommercial, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-NC",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-ND-1.0": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-ND-1.0"
+        ]
+      },
+      "name": "Creative Commons Noderivatives, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-ND",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-ND-2.0": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-ND-2.0"
+        ]
+      },
+      "name": "Creative Commons Noderivatives, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-ND",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-ND-2.5": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-ND-2.5"
+        ]
+      },
+      "name": "Creative Commons Noderivatives, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-ND",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-ND-3.0": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-ND-3.0"
+        ]
+      },
+      "name": "Creative Commons Noderivatives, any version",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-ND",
+        "https://www.gnu.org/licenses/license-list.html"
+      ]
+    },
+    "CC-BY-ND-4.0": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-ND-4.0"
+        ]
+      },
+      "name": "Creative Commons Noderivatives, any version",
+      "tags": [
+        "non-free",
+        "viewpoint"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC-BY-ND",
+        "https://www.gnu.org/licenses/license-list.html",
+        "https://www.gnu.org/licenses/license-list.html#ccbynd",
+        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+      ]
+    },
+    "CC0": {
+      "identifiers": {
+        "spdx": [
+          "CC0-1.0"
+        ]
+      },
+      "name": "CC0",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CC0",
+        "http://directory.fsf.org/wiki/License:CC0"
+      ]
+    },
+    "CDDL": {
+      "identifiers": {
+        "spdx": [
+          "CDDL-1.0"
+        ]
+      },
+      "name": "Common Development and Distribution License (CDDL), version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CDDL",
+        "http://directory.fsf.org/wiki/License:CDDLv1.0"
+      ]
+    },
+    "CPAL": {
+      "identifiers": {
+        "spdx": [
+          "CPAL-1.0"
+        ]
+      },
+      "name": "Common Public Attribution License 1.0 (CPAL)",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CPAL",
+        "https://www.socialtext.net/open/cpal_license_in_wikitext"
+      ]
+    },
+    "CeCILL": {
+      "identifiers": {
+        "spdx": [
+          "CECILL-2.0"
+        ]
+      },
+      "name": "CeCILL version 2",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CeCILL",
+        "https://directory.fsf.org/wiki/License:CeCILLv2"
+      ]
+    },
+    "CeCILL-B": {
+      "identifiers": {
+        "spdx": [
+          "CECILL-B"
+        ]
+      },
+      "name": "CeCILL-B version 1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CeCILL-B",
+        "https://directory.fsf.org/wiki/License:CeCILL-B"
+      ]
+    },
+    "CeCILL-C": {
+      "identifiers": {
+        "spdx": [
+          "CECILL-C"
+        ]
+      },
+      "name": "CeCILL-C version 1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CeCILL-C",
+        "https://directory.fsf.org/wiki/License:CeCILL-C"
+      ]
+    },
+    "ClarifiedArtistic": {
+      "identifiers": {
+        "spdx": [
+          "ClArtistic"
+        ]
+      },
+      "name": "Clarified Artistic License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ClarifiedArtistic",
+        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/"
+      ]
+    },
+    "CommonPublicLicense10": {
+      "identifiers": {
+        "spdx": [
+          "CPL-1.0"
+        ]
+      },
+      "name": "Common Public License Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CommonPublicLicense10",
+        "http://directory.fsf.org/wiki/License:CPLv1.0"
+      ]
+    },
+    "Condor": {
+      "identifiers": {
+        "spdx": [
+          "Condor-1.1"
+        ]
+      },
+      "name": "Condor Public License",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Condor",
+        "http://directory.fsf.org/wiki?title=License:Condor1.1"
+      ]
+    },
+    "CryptixGeneralLicense": {
+      "name": "Cryptix General License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#CryptixGeneralLicense",
+        "http://directory.fsf.org/wiki/License:CryptixGL"
+      ]
+    },
+    "DOR": {
+      "name": "CNRI Digital Object Repository License Agreement",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#DOR",
+        "http://dorepository.org/download.html"
+      ]
+    },
+    "ECL2.0": {
+      "identifiers": {
+        "spdx": [
+          "ECL-2.0"
+        ]
+      },
+      "name": "Educational Community License 2.0",
+      "tags": [
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ECL2.0",
+        "http://directory.fsf.org/wiki/License:ECL2.0"
+      ]
+    },
+    "EPL": {
+      "identifiers": {
+        "spdx": [
+          "EPL-1.0"
+        ]
+      },
+      "name": "Eclipse Public License Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#EPL",
+        "http://directory.fsf.org/wiki/License:EPLv1.0"
+      ]
+    },
+    "EPL2": {
+      "identifiers": {
+        "spdx": [
+          "EPL-2.0"
+        ]
+      },
+      "name": "Eclipse Public License Version 2.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#EPL2",
+        "http://directory.fsf.org/wiki/License:EPLv2.0"
+      ]
+    },
+    "EUDataGrid": {
+      "identifiers": {
+        "spdx": [
+          "EUDatagrid"
+        ]
+      },
+      "name": "EU DataGrid Software License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#EUDataGrid",
+        "http://directory.fsf.org/wiki/License:EUDataGrid"
+      ]
+    },
+    "EUPL": {
+      "identifiers": {
+        "spdx": [
+          "EUPL-1.1"
+        ]
+      },
+      "name": "European Union Public License (EUPL) version 1.1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#EUPL",
+        "http://directory.fsf.org/wiki/License:EUPLv1.1"
+      ]
+    },
+    "Eiffel": {
+      "identifiers": {
+        "spdx": [
+          "EFL-2.0"
+        ]
+      },
+      "name": "Eiffel Forum License, version 2",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Eiffel",
+        "http://directory.fsf.org/wiki/License:EFLv2"
+      ]
+    },
+    "Expat": {
+      "identifiers": {
+        "spdx": [
+          "MIT"
+        ]
+      },
+      "name": "Expat License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Expat",
+        "http://directory.fsf.org/wiki/License:Expat"
+      ]
+    },
+    "FDLv1.1": {
+      "identifiers": {
+        "spdx": [
+          "GFDL-1.1-or-later",
+          "GFDL-1.1-only",
+          "GFDL-1.1"
+        ]
+      },
+      "name": "GNU Free Documentation License",
+      "tags": [
+        "fdl-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#FDL",
+        "https://www.gnu.org/licenses/fdl.html",
+        "https://www.gnu.org/licenses/license-list.html#FDLOther"
+      ]
+    },
+    "FDLv1.2": {
+      "identifiers": {
+        "spdx": [
+          "GFDL-1.2-or-later",
+          "GFDL-1.2-only",
+          "GFDL-1.2"
+        ]
+      },
+      "name": "GNU Free Documentation License",
+      "tags": [
+        "fdl-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#FDL",
+        "https://www.gnu.org/licenses/fdl.html",
+        "https://www.gnu.org/licenses/license-list.html#FDLOther"
+      ]
+    },
+    "FDLv1.3": {
+      "identifiers": {
+        "spdx": [
+          "GFDL-1.3-or-later",
+          "GFDL-1.3-only",
+          "GFDL-1.3"
+        ]
+      },
+      "name": "GNU Free Documentation License",
+      "tags": [
+        "fdl-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#FDL",
+        "https://www.gnu.org/licenses/fdl.html",
+        "https://www.gnu.org/licenses/license-list.html#FDLOther"
+      ]
+    },
+    "FreeArt": {
+      "name": "Free Art License",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#FreeArt",
+        "https://directory.fsf.org/wiki/License:Free-Art-L-v1.3"
+      ]
+    },
+    "FreeBSD": {
+      "identifiers": {
+        "spdx": [
+          "BSD-2-Clause-FreeBSD"
+        ]
+      },
+      "name": "FreeBSD license",
+      "tags": [
+        "fdl-compatible",
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#FreeBSD",
+        "http://directory.fsf.org/wiki?title=License:FreeBSD",
+        "https://www.gnu.org/licenses/license-list.html#FreeBSDDL"
+      ]
+    },
+    "GNUAllPermissive": {
+      "identifiers": {
+        "spdx": [
+          "FSFAP"
+        ]
+      },
+      "name": "GNU All-Permissive License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#GNUAllPermissive",
+        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+      ]
+    },
+    "GNUGPLv3": {
+      "identifiers": {
+        "spdx": [
+          "GPL-3.0-or-later",
+          "GPL-3.0-only",
+          "GPL-3.0"
+        ]
+      },
+      "name": "GNU General Public License (GPL) version 3",
+      "tags": [
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#GNUGPLv3",
+        "https://www.gnu.org/licenses/gpl.html"
+      ]
+    },
+    "GNUVerbatim": {
+      "name": "GNU Verbatim Copying License",
+      "tags": [
+        "viewpoint"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#GNUVerbatim",
+        "https://www.gnu.org/licenses/licenses.html#VerbatimCopying"
+      ]
+    },
+    "GPL-PA": {
+      "name": "GPL for Computer Programs of the Public Administration",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#GPL-PA",
+        "http://directory.fsf.org/wiki/License:GPL-PA"
+      ]
+    },
+    "GPLFonts": {
+      "name": "GNU General Public License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#GPLFonts",
+        "https://www.gnu.org/licenses/gpl.html"
+      ]
+    },
+    "GPLOther": {
+      "name": "GNU General Public License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#GPLOther",
+        "https://www.gnu.org/licenses/gpl.html"
+      ]
+    },
+    "GPLv2": {
+      "identifiers": {
+        "spdx": [
+          "GPL-2.0-or-later",
+          "GPL-2.0-only",
+          "GPL-2.0"
+        ]
+      },
+      "name": "GNU General Public License (GPL) version 2",
+      "tags": [
+        "gpl-2-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#GPLv2",
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
+      ]
+    },
+    "HESSLA": {
+      "name": "Hacktivismo Enhanced-Source Software License Agreement",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#HESSLA",
+        "http://www.hacktivismo.com/about/hessla.php"
+      ]
+    },
+    "HPND": {
+      "identifiers": {
+        "spdx": [
+          "HPND"
+        ]
+      },
+      "name": "Historical Permission Notice and Disclaimer",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#HPND",
+        "http://directory.fsf.org/wiki/License:Historical_Permission_Notice_and_Disclaimer"
+      ]
+    },
+    "IBMPL": {
+      "identifiers": {
+        "spdx": [
+          "IPL-1.0"
+        ]
+      },
+      "name": "IBM Public License, Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#IBMPL",
+        "http://directory.fsf.org/wiki/License:IBMPLv1.0"
+      ]
+    },
+    "IPAFONT": {
+      "identifiers": {
+        "spdx": [
+          "IPA"
+        ]
+      },
+      "name": "IPA\n    Font License",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#IPAFONT",
+        "http://directory.fsf.org/wiki/License:IPA_Font_License"
+      ]
+    },
+    "ISC": {
+      "identifiers": {
+        "spdx": [
+          "ISC"
+        ]
+      },
+      "name": "ISC License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ISC",
+        "http://directory.fsf.org/wiki/License:ISC"
+      ]
+    },
+    "JSON": {
+      "identifiers": {
+        "spdx": [
+          "JSON"
+        ]
+      },
+      "name": "The JSON License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#JSON",
+        "http://directory.fsf.org/wiki/License:JSON"
+      ]
+    },
+    "Jahia": {
+      "name": "Jahia Community Source License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Jahia",
+        "http://web.archive.org/web/20050317081359/http://www.jahia.org/jahia/page145.html"
+      ]
+    },
+    "LGPLv2.1": {
+      "identifiers": {
+        "spdx": [
+          "LGPL-2.1-or-later",
+          "LGPL-2.1-only",
+          "LGPL-2.1"
+        ]
+      },
+      "name": "GNU Lesser General Public License (LGPL) version 2.1",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#LGPLv2.1",
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+      ]
+    },
+    "LGPLv3": {
+      "identifiers": {
+        "spdx": [
+          "LGPL-3.0-or-later",
+          "LGPL-3.0-only",
+          "LGPL-3.0"
+        ]
+      },
+      "name": "GNU Lesser General Public License (LGPL) version 3",
+      "tags": [
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#LGPLv3",
+        "https://www.gnu.org/licenses/lgpl.html"
+      ]
+    },
+    "LPPL-1.2": {
+      "identifiers": {
+        "spdx": [
+          "LPPL-1.2"
+        ]
+      },
+      "name": "LaTeX Project Public License 1.2",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#LPPL-1.2",
+        "http://directory.fsf.org/wiki/License:LPPLv1.2"
+      ]
+    },
+    "LPPL-1.3a": {
+      "identifiers": {
+        "spdx": [
+          "LPPL-1.3a"
+        ]
+      },
+      "name": "LaTeX Project Public License 1.3a",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#LPPL-1.3a",
+        "http://directory.fsf.org/wiki/License:LPPLv1.3a"
+      ]
+    },
+    "Lha": {
+      "name": "License of Lha",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Lha",
+        "http://directory.fsf.org/wiki/License:Lha"
+      ]
+    },
+    "MPL": {
+      "identifiers": {
+        "spdx": [
+          "MPL-1.1"
+        ]
+      },
+      "name": "Mozilla Public License (MPL) version 1.1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#MPL",
+        "http://directory.fsf.org/wiki/License:MPLv1.1"
+      ]
+    },
+    "MPL-2.0": {
+      "identifiers": {
+        "spdx": [
+          "MPL-2.0"
+        ]
+      },
+      "name": "Mozilla Public\n       License (MPL) version 2.0",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#MPL-2.0",
+        "http://directory.fsf.org/wiki/License:MPLv2.0"
+      ]
+    },
+    "ModifiedBSD": {
+      "identifiers": {
+        "spdx": [
+          "BSD-3-Clause"
+        ]
+      },
+      "name": "Modified BSD license",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ModifiedBSD",
+        "http://directory.fsf.org/wiki/License:BSD_3Clause"
+      ]
+    },
+    "Ms-SS": {
+      "name": "Microsoft's Shared Source CLI, C#, and Jscript License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Ms-SS",
+        "http://directory.fsf.org/wiki/License:Ms-SS"
+      ]
+    },
+    "NASA": {
+      "identifiers": {
+        "spdx": [
+          "NASA-1.3"
+        ]
+      },
+      "name": "NASA Open Source Agreement",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#NASA",
+        "http://directory.fsf.org/wiki/License:NASA-OSA_v1.3"
+      ]
+    },
+    "NCSA": {
+      "identifiers": {
+        "spdx": [
+          "NCSA"
+        ]
+      },
+      "name": "NCSA/University of Illinois Open Source License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#NCSA",
+        "http://directory.fsf.org/wiki/License:IllinoisNCSA"
+      ]
+    },
+    "NOSL": {
+      "identifiers": {
+        "spdx": [
+          "NOSL"
+        ]
+      },
+      "name": "Netizen Open Source License (NOSL), Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#NOSL",
+        "http://directory.fsf.org/wiki/License:NOSLv1.0"
+      ]
+    },
+    "NPL-1.0": {
+      "identifiers": {
+        "spdx": [
+          "NPL-1.0"
+        ]
+      },
+      "name": "Netscape Public License (NPL)",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#NPL",
+        "http://directory.fsf.org/wiki?title=License:NPLv1.1"
+      ]
+    },
+    "NPL-1.1": {
+      "identifiers": {
+        "spdx": [
+          "NPL-1.1"
+        ]
+      },
+      "name": "Netscape Public License (NPL)",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#NPL",
+        "http://directory.fsf.org/wiki?title=License:NPLv1.1"
+      ]
+    },
+    "NoLicense": {
+      "identifiers": {
+        "spdx": [
+          "NONE"
+        ]
+      },
+      "name": "No license",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#NoLicense"
+      ]
+    },
+    "Nokia": {
+      "identifiers": {
+        "spdx": [
+          "Nokia"
+        ]
+      },
+      "name": "Nokia Open Source License",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Nokia",
+        "http://directory.fsf.org/wiki/License:NokOSv1.0a"
+      ]
+    },
+    "ODbl": {
+      "identifiers": {
+        "spdx": [
+          "ODbL-1.0"
+        ]
+      },
+      "name": "Open Database license",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ODbl",
+        "http://directory.fsf.org/wiki/License:ODbl"
+      ]
+    },
+    "OSL-1.0": {
+      "identifiers": {
+        "spdx": [
+          "OSL-1.0"
+        ]
+      },
+      "name": "Open Software License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OSL",
+        "http://directory.fsf.org/wiki/License:OSLv3.0"
+      ]
+    },
+    "OSL-1.1": {
+      "identifiers": {
+        "spdx": [
+          "OSL-1.1"
+        ]
+      },
+      "name": "Open Software License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OSL",
+        "http://directory.fsf.org/wiki/License:OSLv3.0"
+      ]
+    },
+    "OSL-2.0": {
+      "identifiers": {
+        "spdx": [
+          "OSL-2.0"
+        ]
+      },
+      "name": "Open Software License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OSL",
+        "http://directory.fsf.org/wiki/License:OSLv3.0"
+      ]
+    },
+    "OSL-2.1": {
+      "identifiers": {
+        "spdx": [
+          "OSL-2.1"
+        ]
+      },
+      "name": "Open Software License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OSL",
+        "http://directory.fsf.org/wiki/License:OSLv3.0"
+      ]
+    },
+    "OSL-3.0": {
+      "identifiers": {
+        "spdx": [
+          "OSL-3.0"
+        ]
+      },
+      "name": "Open Software License, all versions through 3.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OSL",
+        "http://directory.fsf.org/wiki/License:OSLv3.0"
+      ]
+    },
+    "OculusRift": {
+      "name": "Oculus Rift SDK License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OculusRift",
+        "http://directory.fsf.org/wiki/License:Oculus_VR_Rift_SDK_License"
+      ]
+    },
+    "OpenContentL": {
+      "name": "Open Content License, Version 1.0",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OpenContentL",
+        "https://web.archive.org/web/19981206111937/http://www.opencontent.org/opl.shtml"
+      ]
+    },
+    "OpenPublicL": {
+      "identifiers": {
+        "spdx": [
+          "OPL-1.0"
+        ]
+      },
+      "name": "Open Public License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OpenPublicL",
+        "http://directory.fsf.org/wiki/License:OpenPLv1.0"
+      ]
+    },
+    "OpenPublicationL": {
+      "name": "Open Publication License, Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OpenPublicationL",
+        "http://opencontent.org/openpub/"
+      ]
+    },
+    "OpenSSL": {
+      "identifiers": {
+        "spdx": [
+          "OpenSSL"
+        ]
+      },
+      "name": "OpenSSL license",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OpenSSL",
+        "http://directory.fsf.org/wiki/License:OpenSSL"
+      ]
+    },
+    "OriginalBSD": {
+      "identifiers": {
+        "spdx": [
+          "BSD-4-Clause"
+        ]
+      },
+      "name": "Original BSD license",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#OriginalBSD",
+        "http://directory.fsf.org/wiki/License:BSD_4Clause"
+      ]
+    },
+    "PHP-3.01": {
+      "identifiers": {
+        "spdx": [
+          "PHP-3.01"
+        ]
+      },
+      "name": "PHP License, Version 3.01",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#PHP-3.01",
+        "http://directory.fsf.org/wiki/License:PHPv3.01"
+      ]
+    },
+    "PINE": {
+      "name": "License of PINE",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#PINE",
+        "http://directory.fsf.org/wiki/License:PINE"
+      ]
+    },
+    "PPL": {
+      "name": "Peer-Production License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#PPL",
+        "http://directory.fsf.org/wiki/License:PPL"
+      ]
+    },
+    "PerlLicense": {
+      "name": "License of Perl 5 and below",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#PerlLicense"
+      ]
+    },
+    "Phorum": {
+      "name": "Phorum License, Version 2.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Phorum",
+        "http://directory.fsf.org/wiki/License:Phorum2.0"
+      ]
+    },
+    "Plan9": {
+      "name": "Old Plan 9 license",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Plan9"
+      ]
+    },
+    "PublicDomain": {
+      "name": "Public Domain",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#PublicDomain",
+        "http://directory.fsf.org/wiki/License:PublicDomain"
+      ]
+    },
+    "Python": {
+      "name": "License of Python 2.0.1, 2.1.1, and newer versions",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Python",
+        "http://directory.fsf.org/wiki?title=License:Python2.0.1"
+      ]
+    },
+    "Python1.6a2": {
+      "name": "License of Python 1.6a2 and earlier versions",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Python1.6a2",
+        "http://directory.fsf.org/wiki?title=License:Python1.6a2"
+      ]
+    },
+    "Python1.6b1": {
+      "name": "License of Python 1.6b1 through 2.0 and 2.1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#PythonOld",
+        "http://directory.fsf.org/wiki/License:Python1.6b1"
+      ]
+    },
+    "Python2.0": {
+      "identifiers": {
+        "spdx": [
+          "Python-2.0"
+        ]
+      },
+      "name": "License of Python 1.6b1 through 2.0 and 2.1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#PythonOld",
+        "http://directory.fsf.org/wiki/License:Python1.6b1"
+      ]
+    },
+    "Python2.1": {
+      "name": "License of Python 1.6b1 through 2.0 and 2.1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#PythonOld",
+        "http://directory.fsf.org/wiki/License:Python1.6b1"
+      ]
+    },
+    "QPL": {
+      "identifiers": {
+        "spdx": [
+          "QPL-1.0"
+        ]
+      },
+      "name": "Q Public License (QPL), Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#QPL",
+        "http://directory.fsf.org/wiki/License:QPLv1.0"
+      ]
+    },
+    "RPL": {
+      "name": "Reciprocal Public License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#RPL",
+        "http://directory.fsf.org/wiki/License:ReciprocalPLv1.3"
+      ]
+    },
+    "RPSL": {
+      "identifiers": {
+        "spdx": [
+          "RPSL-1.0"
+        ]
+      },
+      "name": "RealNetworks Public Source License (RPSL), Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#RPSL",
+        "http://directory.fsf.org/wiki/License:RPSLv1.0"
+      ]
+    },
+    "Ruby": {
+      "identifiers": {
+        "spdx": [
+          "Ruby"
+        ]
+      },
+      "name": "License of Ruby",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Ruby",
+        "http://directory.fsf.org/wiki/License:Ruby"
+      ]
+    },
+    "SGIFreeB": {
+      "identifiers": {
+        "spdx": [
+          "SGI-B-2.0"
+        ]
+      },
+      "name": "SGI Free Software License B, version 2.0",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#SGIFreeB",
+        "http://directory.fsf.org/wiki/License:SGIFreeBv2"
+      ]
+    },
+    "SILOFL": {
+      "identifiers": {
+        "spdx": [
+          "OFL-1.1"
+        ]
+      },
+      "name": "SIL Open Font License 1.1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#SILOFL",
+        "http://directory.fsf.org/wiki/SIL_Open_Font_License_1.1"
+      ]
+    },
+    "SISSL": {
+      "name": "Sun Industry Standards Source License 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#SISSL",
+        "http://www.openoffice.org/licenses/sissl_license.html"
+      ]
+    },
+    "SML": {
+      "name": "Simple Machines License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#SML",
+        "http://directory.fsf.org/wiki/License:SimpleM"
+      ]
+    },
+    "SPL": {
+      "identifiers": {
+        "spdx": [
+          "SPL-1.0"
+        ]
+      },
+      "name": "Sun Public License",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#SPL",
+        "http://directory.fsf.org/wiki/License:SPLv1.0"
+      ]
+    },
+    "Scilab": {
+      "name": "Scilab license",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Scilab",
+        "http://directory.fsf.org/wiki/License:Scilab-old"
+      ]
+    },
+    "Scratch": {
+      "name": "Scratch 1.4 license",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Scratch",
+        "http://directory.fsf.org/wiki/License:Scratch"
+      ]
+    },
+    "Squeak": {
+      "name": "Old Squeak license",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Squeak",
+        "http://directory.fsf.org/wiki/License:Squeak-old"
+      ]
+    },
+    "StandardMLofNJ": {
+      "identifiers": {
+        "spdx": [
+          "SMLNJ"
+        ]
+      },
+      "name": "Standard ML of New Jersey Copyright License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#StandardMLofNJ",
+        "http://directory.fsf.org/wiki/License:StandardMLofNJ"
+      ]
+    },
+    "SunCommunitySourceLicense": {
+      "name": "Sun Community Source License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#SunCommunitySourceLicense",
+        "http://directory.fsf.org/wiki/License:SunCSLv2.8"
+      ]
+    },
+    "SunSolarisSourceCode": {
+      "name": "Sun Solaris Source Code (Foundation Release) License, Version 1.1",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#SunSolarisSourceCode"
+      ]
+    },
+    "SystemC-3.0": {
+      "name": "SystemC",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#SystemC-3.0",
+        "http://www.accellera.org/about/policies/SystemC_Open_Source_License.pdf"
+      ]
+    },
+    "Truecrypt-3.0": {
+      "name": "Truecrypt license 3.0",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Truecrypt-3.0",
+        "http://directory.fsf.org/wiki/License:TrueCrypt"
+      ]
+    },
+    "UPL": {
+      "identifiers": {
+        "spdx": [
+          "UPL-1.0"
+        ]
+      },
+      "name": "Universal Permissive License (UPL)",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#UPL",
+        "http://directory.fsf.org/wiki/License:Universal_Permissive_License"
+      ]
+    },
+    "Unicode": {
+      "name": "Unicode, Inc. License Agreement for Data Files and Software",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Unicode",
+        "http://directory.fsf.org/wiki/License:Unicode"
+      ]
+    },
+    "Unlicense": {
+      "identifiers": {
+        "spdx": [
+          "Unlicense"
+        ]
+      },
+      "name": "The Unlicense",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Unlicense",
+        "http://directory.fsf.org/wiki/License:TheUnlicense"
+      ]
+    },
+    "UtahPublicLicense": {
+      "name": "University of Utah Public License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#UtahPublicLicense",
+        "http://www.cs.utah.edu/~gk/teem/txt/LICENSE.txt"
+      ]
+    },
+    "Vim": {
+      "identifiers": {
+        "spdx": [
+          "Vim"
+        ]
+      },
+      "name": "License of Vim, Version 6.1 or later",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Vim",
+        "http://directory.fsf.org/wiki/License:Vim7.2"
+      ]
+    },
+    "W3C": {
+      "identifiers": {
+        "spdx": [
+          "W3C"
+        ]
+      },
+      "name": "W3C Software Notice and License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#W3C",
+        "http://directory.fsf.org/wiki/License:W3C_31Dec2002"
+      ]
+    },
+    "WTFPL": {
+      "identifiers": {
+        "spdx": [
+          "WTFPL"
+        ]
+      },
+      "name": "WTFPL, Version 2",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#WTFPL",
+        "http://sam.zoy.org/wtfpl/COPYING"
+      ]
+    },
+    "Watcom": {
+      "identifiers": {
+        "spdx": [
+          "Watcom-1.0"
+        ]
+      },
+      "name": "Sybase Open Watcom Public License version 1.0",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Watcom",
+        "ftp://ftp.openwatcom.org/install/license.txt"
+      ]
+    },
+    "WebM": {
+      "name": "License of WebM",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#WebM",
+        "http://directory.fsf.org/wiki/License:WebM"
+      ]
+    },
+    "X11License": {
+      "identifiers": {
+        "spdx": [
+          "X11"
+        ]
+      },
+      "name": "X11 License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#X11License",
+        "http://directory.fsf.org/wiki/License:X11"
+      ]
+    },
+    "XFree861.1License": {
+      "identifiers": {
+        "spdx": [
+          "XFree86-1.1"
+        ]
+      },
+      "name": "XFree86 1.1 License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#XFree861.1License",
+        "http://directory.fsf.org/wiki/License:XFree86_1.1"
+      ]
+    },
+    "YaST": {
+      "name": "YaST License",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#YaST"
+      ]
+    },
+    "Yahoo": {
+      "identifiers": {
+        "spdx": [
+          "YPL-1.1"
+        ]
+      },
+      "name": "Yahoo! Public License 1.1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Yahoo",
+        "http://directory.fsf.org/wiki/License:YPLv1.1"
+      ]
+    },
+    "ZLib": {
+      "identifiers": {
+        "spdx": [
+          "Zlib"
+        ]
+      },
+      "name": "License of ZLib",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ZLib",
+        "http://directory.fsf.org/wiki/License:Zlib"
+      ]
+    },
+    "Zend": {
+      "identifiers": {
+        "spdx": [
+          "Zend-2.0"
+        ]
+      },
+      "name": "Zend License, Version 2.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Zend",
+        "http://directory.fsf.org/wiki/License:ZELv2.0"
+      ]
+    },
+    "Zimbra": {
+      "identifiers": {
+        "spdx": [
+          "Zimbra-1.3"
+        ]
+      },
+      "name": "Zimbra Public License 1.3",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Zimbra",
+        "http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ]
+    },
+    "Zope": {
+      "name": "Zope Public License version 1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Zope",
+        "http://web.archive.org/web/20000816090640/http://www.zope.org/Resources/ZPL"
+      ]
+    },
+    "Zope2.0": {
+      "identifiers": {
+        "spdx": [
+          "ZPL-2.0"
+        ]
+      },
+      "name": "Zope Public License, versions 2.0 and 2.1",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Zope2.0",
+        "http://directory.fsf.org/wiki?title=License:ZopePLv2.1"
+      ]
+    },
+    "Zope2.1": {
+      "identifiers": {
+        "spdx": [
+          "ZPL-2.1"
+        ]
+      },
+      "name": "Zope Public License, versions 2.0 and 2.1",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#Zope2.0",
+        "http://directory.fsf.org/wiki?title=License:ZopePLv2.1"
+      ]
+    },
+    "apache1": {
+      "identifiers": {
+        "spdx": [
+          "Apache-1.0"
+        ]
+      },
+      "name": "Apache License, Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#apache1",
+        "http://directory.fsf.org/wiki/License:Apache1.0"
+      ]
+    },
+    "apache1.1": {
+      "identifiers": {
+        "spdx": [
+          "Apache-1.1"
+        ]
+      },
+      "name": "Apache License, Version 1.1",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#apache1.1",
+        "http://directory.fsf.org/wiki/License:Apache1.1"
+      ]
+    },
+    "apache2": {
+      "identifiers": {
+        "spdx": [
+          "Apache-2.0"
+        ]
+      },
+      "name": "Apache License, Version 2.0",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#apache2",
+        "http://directory.fsf.org/wiki/License:Apache2.0"
+      ]
+    },
+    "apsl1": {
+      "identifiers": {
+        "spdx": [
+          "APSL-1.0"
+        ]
+      },
+      "name": "Apple Public Source License (APSL), version 1.x",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#apsl1",
+        "http://directory.fsf.org/wiki/License:APSLv1.x"
+      ]
+    },
+    "apsl2": {
+      "identifiers": {
+        "spdx": [
+          "APSL-2.0"
+        ]
+      },
+      "name": "Apple Public Source License (APSL), version 2",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#apsl2",
+        "http://directory.fsf.org/wiki/License:APSLv2.0"
+      ]
+    },
+    "bittorrent": {
+      "identifiers": {
+        "spdx": [
+          "BitTorrent-1.1"
+        ]
+      },
+      "name": "BitTorrent Open Source License",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#bittorrent",
+        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+      ]
+    },
+    "boost": {
+      "identifiers": {
+        "spdx": [
+          "BSL-1.0"
+        ]
+      },
+      "name": "Boost Software License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#boost",
+        "http://directory.fsf.org/wiki/License:Boost1.0"
+      ]
+    },
+    "ccby": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-4.0"
+        ]
+      },
+      "name": "Creative Commons Attribution 4.0 license",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ccby",
+        "http://creativecommons.org/licenses/by/4.0/legalcode"
+      ]
+    },
+    "ccbysa": {
+      "identifiers": {
+        "spdx": [
+          "CC-BY-SA-4.0"
+        ]
+      },
+      "name": "Creative Commons Attribution-Sharealike 4.0 license",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ccbysa",
+        "http://creativecommons.org/licenses/by-sa/4.0/legalcode"
+      ]
+    },
+    "clearbsd": {
+      "identifiers": {
+        "spdx": [
+          "BSD-3-Clause-Clear"
+        ]
+      },
+      "name": "The Clear BSD License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#clearbsd",
+        "http://directory.fsf.org/wiki/License:ClearBSD"
+      ]
+    },
+    "cpol": {
+      "identifiers": {
+        "spdx": [
+          "CPOL-1.02"
+        ]
+      },
+      "name": "Code Project Open License, version 1.02",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#cpol"
+      ]
+    },
+    "dsl": {
+      "name": "Design Science License (DSL)",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#dsl",
+        "https://www.gnu.org/licenses/dsl.html"
+      ]
+    },
+    "eCos11": {
+      "identifiers": {
+        "spdx": [
+          "RHeCos-1.1"
+        ]
+      },
+      "name": "eCos Public License, version 1.1",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#eCos11",
+        "http://directory.fsf.org/wiki/License:ECosPLv1.1"
+      ]
+    },
+    "eCos2.0": {
+      "identifiers": {
+        "spdx": [
+          "GPL-2.0+ WITH eCos-exception-2.0"
+        ]
+      },
+      "name": "eCos license version 2.0",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#eCos2.0",
+        "http://directory.fsf.org/wiki/License:ECos2.0"
+      ]
+    },
+    "ecfonts": {
+      "name": "License\n       of the ec fonts for LaTeX",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ecfonts",
+        "http://directory.fsf.org/wiki/License:LaTeX_ecfonts"
+      ]
+    },
+    "freetype": {
+      "identifiers": {
+        "spdx": [
+          "FTL"
+        ]
+      },
+      "name": "Freetype Project License",
+      "tags": [
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#freetype",
+        "http://directory.fsf.org/wiki/License:FreeType"
+      ]
+    },
+    "gnuplot": {
+      "identifiers": {
+        "spdx": [
+          "gnuplot"
+        ]
+      },
+      "name": "Gnuplot license",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#gnuplot",
+        "http://directory.fsf.org/wiki/License:Gnuplot"
+      ]
+    },
+    "iMatix": {
+      "identifiers": {
+        "spdx": [
+          "iMatix"
+        ]
+      },
+      "name": "License of the iMatix Standard Function Library",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#iMatix",
+        "http://directory.fsf.org/wiki?title=License:SFL"
+      ]
+    },
+    "ijg": {
+      "identifiers": {
+        "spdx": [
+          "IJG"
+        ]
+      },
+      "name": "Independent JPEG Group License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ijg",
+        "http://directory.fsf.org/wiki?title=License:JPEG"
+      ]
+    },
+    "imlib": {
+      "identifiers": {
+        "spdx": [
+          "Imlib2"
+        ]
+      },
+      "name": "License of imlib2",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#imlib",
+        "http://directory.fsf.org/wiki/License:Imlib2"
+      ]
+    },
+    "informal": {
+      "name": "Informal license",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#informal"
+      ]
+    },
+    "intel": {
+      "identifiers": {
+        "spdx": [
+          "Intel"
+        ]
+      },
+      "name": "Intel Open Source License",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#intel",
+        "http://directory.fsf.org/wiki/License:IntelACPI"
+      ]
+    },
+    "josl": {
+      "name": "Jabber Open Source License, Version 1.0",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#josl",
+        "http://directory.fsf.org/wiki/License:JabberOSLv1.0"
+      ]
+    },
+    "ksh93": {
+      "name": "Old license of ksh93",
+      "tags": [
+        "non-free"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ksh93"
+      ]
+    },
+    "lucent102": {
+      "identifiers": {
+        "spdx": [
+          "LPL-1.02"
+        ]
+      },
+      "name": "Lucent Public License Version 1.02 (Plan 9 license)",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#lucent102",
+        "http://directory.fsf.org/wiki/License:LucentPLv1.02"
+      ]
+    },
+    "ms-pl": {
+      "identifiers": {
+        "spdx": [
+          "MS-PL"
+        ]
+      },
+      "name": "Microsoft Public License (Ms-PL)",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ms-pl",
+        "http://directory.fsf.org/wiki/License:MsPL"
+      ]
+    },
+    "ms-rl": {
+      "identifiers": {
+        "spdx": [
+          "MS-RL"
+        ]
+      },
+      "name": "Microsoft Reciprocal License (Ms-RL)",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#ms-rl",
+        "http://directory.fsf.org/wiki/License:MsRL"
+      ]
+    },
+    "newOpenLDAP": {
+      "identifiers": {
+        "spdx": [
+          "OLDAP-2.7"
+        ]
+      },
+      "name": "OpenLDAP License, Version 2.7",
+      "tags": [
+        "gpl-2-compatible",
+        "gpl-3-compatible",
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#newOpenLDAP",
+        "http://directory.fsf.org/wiki/License:OpenLDAPv2.7"
+      ]
+    },
+    "oldOpenLDAP": {
+      "identifiers": {
+        "spdx": [
+          "OLDAP-2.3"
+        ]
+      },
+      "name": "Old OpenLDAP License, Version 2.3",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#oldOpenLDAP",
+        "http://directory.fsf.org/wiki/License:OpenLDAPv2.3"
+      ]
+    },
+    "xinetd": {
+      "identifiers": {
+        "spdx": [
+          "xinetd"
+        ]
+      },
+      "name": "License of xinetd",
+      "tags": [
+        "libre"
+      ],
+      "uris": [
+        "https://www.gnu.org/licenses/license-list.html#xinetd",
+        "http://directory.fsf.org/wiki/License:Xinetd"
+      ]
+    }
   }
 }

--- a/resources/licenses-full.json
+++ b/resources/licenses-full.json
@@ -1,5 +1,24 @@
 {
-  "@context": "https://wking.github.io/fsf-api/schema/licenses.jsonld",
+  "@context": {
+	  "@vocab": "http://tremily.us/fsf/schema/license.jsonld",
+	    "schema": "http://schema.org/",
+	    "identifiers": {
+	      "@id": "schema:identifier"
+	    },
+	    "id": {
+	      "@id": "schema:identifier"
+	    },
+	    "tags": {
+	      "@id": "schema:keywords"
+	    },
+	    "name": {
+	      "@id": "schema:name"
+	    },
+	    "uris": {
+	      "@container": "@list",
+	      "@id": "schema:url"
+	    }
+  },
   "licenses": {
     "ACDL": {
       "name": "Apple's Common Documentation License, Version 1.0",

--- a/src/org/spdx/tools/licensegenerator/FsfLicenseDataParser.java
+++ b/src/org/spdx/tools/licensegenerator/FsfLicenseDataParser.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
@@ -63,7 +64,7 @@ public class FsfLicenseDataParser {
 	static final String FSF_JSON_FILE_PATH = "resources" + File.separator + "licenses-full.json";
 	static final String FSF_JSON_CLASS_PATH = "resources/licenses-full.json";
 
-	static final String FSF_JSON_NAMESPACE = "https://wking.github.io/fsf-api/schema/";
+	static final String FSF_JSON_NAMESPACE = "http://tremily.us/fsf/schema/";
 	static final String PROPERTY_TAGS = "license.jsonldtags";
 	private static final String PROPERTY_SPDXID = "license.jsonldspdx";
 	private static final String PROPERTY_IDENTIFIERS = "license.jsonldidentifiers";
@@ -114,6 +115,10 @@ public class FsfLicenseDataParser {
 			Node p = model.getProperty(FSF_JSON_NAMESPACE, PROPERTY_TAGS).asNode();
 			Triple m = Triple.createMatch(null, p, null);
 			ExtendedIterator<Triple> tripleIter = model.getGraph().find(m);	
+			StringWriter sw = new StringWriter();
+			model.write(sw);
+			String debug = sw.toString();
+			
 			while (tripleIter.hasNext()) {
 				Triple t = tripleIter.next();
 				if (t.getObject().isLiteral()) {

--- a/src/org/spdx/tools/licensegenerator/FsfLicenseDataParser.java
+++ b/src/org/spdx/tools/licensegenerator/FsfLicenseDataParser.java
@@ -15,23 +15,22 @@
  */
 package org.spdx.tools.licensegenerator;
 
-import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
-import org.json.simple.parser.ParseException;
+import org.apache.jena.ext.com.google.common.collect.Lists;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.util.iterator.ExtendedIterator;
 import org.spdx.tools.LicenseGeneratorException;
 
 import com.google.common.collect.Maps;
@@ -63,7 +62,12 @@ public class FsfLicenseDataParser {
 	static final String DEFAULT_FSF_JSON_URL = "https://wking.github.io/fsf-api/licenses-full.json";
 	static final String FSF_JSON_FILE_PATH = "resources" + File.separator + "licenses-full.json";
 	static final String FSF_JSON_CLASS_PATH = "resources/licenses-full.json";
-	
+
+	static final String FSF_JSON_NAMESPACE = "https://wking.github.io/fsf-api/schema/";
+	static final String PROPERTY_TAGS = "license.jsonldtags";
+	private static final String PROPERTY_SPDXID = "license.jsonldspdx";
+	private static final String PROPERTY_IDENTIFIERS = "license.jsonldidentifiers";
+		
 	private static FsfLicenseDataParser fsfLicenseDataParser = null;
 	private Map<String, Boolean> licenseIdToFsfFree;
 	private boolean useOnlyLocalFile = false;
@@ -73,73 +77,103 @@ public class FsfLicenseDataParser {
 		licenseIdToFsfFree = Maps.newHashMap();
 		useOnlyLocalFile = Boolean.parseBoolean(System.getProperty(PROP_USE_ONLY_LOCAL_FILE, "false"));
 		licenseJsonUrl = System.getProperty(PROP_FSF_FREE_JSON_URL, DEFAULT_FSF_JSON_URL);
-		Reader reader = null;
+		InputStream input = null;
+		ClassLoader oldContextCL = Thread.currentThread().getContextClassLoader();
 		try {
+			Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
 			if (!useOnlyLocalFile) {
 				// First, try the URL
 				try {
 					URL url = new URL(licenseJsonUrl);
-					reader = new BufferedReader(new InputStreamReader(url.openStream()));
+					input = url.openStream();
 				} catch (MalformedURLException e) {
-					reader = null;
+					input = null;
 				} catch (IOException e) {
-					reader = null;
+					input = null;
 				}
 			}
-			if (reader == null) {
+			if (input == null) {
 				// try the file system
 				try {
-					reader = new BufferedReader(new FileReader(FSF_JSON_FILE_PATH));
+					input = new FileInputStream(FSF_JSON_FILE_PATH);
 				} catch (FileNotFoundException e) {
-					reader = null;
+					input = null;
 				}
 			}
-			if (reader == null) {
+			if (input == null) {
 				try {
-					reader = new BufferedReader(new FileReader(FSF_JSON_CLASS_PATH));
+					input = new FileInputStream(FSF_JSON_FILE_PATH);
 				} catch (FileNotFoundException e) {
 					throw new LicenseGeneratorException("Unable to open reader for the FSF API");
 				}
 			}
-			JSONObject fsfLicenses = (JSONObject)JSONValue.parseWithException(reader);
-			@SuppressWarnings("unchecked")
-			Iterator<Entry<String, JSONObject>> iter = fsfLicenses.entrySet().iterator();
-			while (iter.hasNext()) {
-				Entry<String, JSONObject> entry = iter.next();
-				JSONObject fsfLicense = (JSONObject)entry.getValue();
-				JSONObject identifiers = (JSONObject)fsfLicense.get("identifiers");
-				if (identifiers != null) {
-					String spdxId = (String)identifiers.get("spdx");
-					if (spdxId != null) {
-						Boolean fsfLibre = false;
-						JSONArray tags = (JSONArray)fsfLicense.get("tags");
-						if (tags != null) {
-							for (Object tag:tags) {
-								if ("libre".equals(tag)) {
-									fsfLibre = true;
-									break;
-								}
-							}
+
+			Model model = ModelFactory.createDefaultModel();
+			model.read(input, null, "JSON-LD");
+			
+			Node p = model.getProperty(FSF_JSON_NAMESPACE, PROPERTY_TAGS).asNode();
+			Triple m = Triple.createMatch(null, p, null);
+			ExtendedIterator<Triple> tripleIter = model.getGraph().find(m);	
+			while (tripleIter.hasNext()) {
+				Triple t = tripleIter.next();
+				if (t.getObject().isLiteral()) {
+					String objectVal = t.getObject().toString(false);
+					if ("libre".equals(objectVal)) {
+						Node subject = t.getSubject();
+						List<String> spdxIds = findSpdxIds(subject, model);
+						for (String spdxId:spdxIds) {
+							this.licenseIdToFsfFree.put(spdxId,true);
 						}
-						this.licenseIdToFsfFree.put(spdxId, fsfLibre);
 					}
 				}
 			}
-		} catch (IOException e) {
-			throw new LicenseGeneratorException("IO error reading FSF license information");
-		} catch (ParseException e) {
-			throw new LicenseGeneratorException("Parsing error reading FSF license information");
+		} catch(Exception ex) {
+			throw new LicenseGeneratorException("Error parsing FSF license data");
 		} finally {
-			if (reader != null) {
+			if (input != null) {
 				try {
-					reader.close();
+					input.close();
 				} catch (IOException e) {
-					throw new LicenseGeneratorException("Unable to close reader for the FSF API");
+					throw new LicenseGeneratorException("Unable to close input for the FSF API");
 				}
 			}
+			Thread.currentThread().setContextClassLoader(oldContextCL);
 		}
 	}
 	
+	/**
+	 * @param subject Subject of the RDF triple which contains the SPDX ID's
+	 * @param model
+	 * @return all SPDX ID's associated with the subject
+	 * @throws LicenseGeneratorException 
+	 */
+	private List<String> findSpdxIds(Node subject, Model model) throws LicenseGeneratorException {
+		Node identifiersProp = model.getProperty(FSF_JSON_NAMESPACE, PROPERTY_IDENTIFIERS).asNode();
+		Triple identifersMatch = Triple.createMatch(subject, identifiersProp, null);
+		ExtendedIterator<Triple> identifiersIterator = model.getGraph().find(identifersMatch);
+		List<String> retval = Lists.newArrayList();
+		while (identifiersIterator.hasNext()) {
+			Node identifiersObject = identifiersIterator.next().getObject();
+			if (identifiersObject == null) {
+				continue;
+			}
+			Node spdxIdProp = model.getProperty(FSF_JSON_NAMESPACE, PROPERTY_SPDXID).asNode();
+			Triple spdxIdMatch = Triple.createMatch(identifiersObject, spdxIdProp, null);
+			ExtendedIterator<Triple> spdxIdIterator = model.getGraph().find(spdxIdMatch);
+			while (spdxIdIterator.hasNext()) {
+				Node spdxIdObject = spdxIdIterator.next().getObject();
+				if (spdxIdObject == null) {
+					continue;
+				}
+				if (!spdxIdObject.isLiteral()) {
+					throw new LicenseGeneratorException("SPDX ID is not a literal");
+				}
+				retval.add(spdxIdObject.toString(false));
+			}
+		}
+		return retval;
+	}
+
 	public static synchronized FsfLicenseDataParser getFsfLicenseDataParser() throws LicenseGeneratorException {
 		if (fsfLicenseDataParser == null) {
 			fsfLicenseDataParser = new FsfLicenseDataParser();


### PR DESCRIPTION
See https://github.com/wking/fsf-api/pull/12 for information on the change.

This change should not be merged until https://github.com/wking/fsf-api/pull/12 has been merged.