### PR TITLE
Updating TagToRdf Online function to take the optional output file type argument. In response to PR #13 and Issue #8 of online tools.

### DIFF
--- a/src/org/spdx/tools/TagToRDF.java
+++ b/src/org/spdx/tools/TagToRDF.java
@@ -103,6 +103,9 @@ public class TagToRDF {
 	public static List<String> onlineFunction(String[] args) throws OnlineToolException{
 		// Arguments length(args length== 2 ) will checked in the Python Code
 		String outputFormat = DEFAULT_OUTPUT_FORMAT;
+		if (args.length > 2) {
+			outputFormat = args[2];
+		}
 		FileInputStream spdxTagStream;
 		try {
 			spdxTagStream = new FileInputStream(args[0]);


### PR DESCRIPTION
PR [#13](https://github.com/spdx/spdx-online-tools/pull/13) in spdx-online-tools.


Signed-off-by: rtgdk <rohit.lodhartg@gmail.com>