### PR TITLE
Sort the JSON license table of content.  

### DIFF
--- a/Test/org/spdx/html/TestLicenseTOCJSONFile.java
+++ b/Test/org/spdx/html/TestLicenseTOCJSONFile.java
@@ -1,0 +1,75 @@
+package org.spdx.html;
+
+import static org.junit.Assert.*;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.spdx.rdfparser.SpdxRdfConstants;
+import org.spdx.rdfparser.license.AnyLicenseInfo;
+import org.spdx.rdfparser.license.LicenseInfoFactory;
+import org.spdx.rdfparser.license.SpdxListedLicense;
+import org.spdx.spdxspreadsheet.InvalidLicenseStringException;
+
+public class TestLicenseTOCJSONFile {
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void testGetJsonObject() throws InvalidLicenseStringException {
+		String version = "12.0";
+		String releaseDate = "12/12/2018";
+		LicenseTOCJSONFile tocJson = new LicenseTOCJSONFile(version, releaseDate);
+		
+		SpdxListedLicense zeroBSD = (SpdxListedLicense)LicenseInfoFactory.parseSPDXLicenseString("0BSD");
+		String zeroBSDLicHtmlRef = "license/0BSD";
+		String zeroBSDLicJsonRef = "json/0BSD";
+		boolean zeroBSDDeprecated = false;
+		tocJson.addLicense(zeroBSD, zeroBSDLicHtmlRef, zeroBSDLicJsonRef, zeroBSDDeprecated);
+		
+		SpdxListedLicense zlib = (SpdxListedLicense)LicenseInfoFactory.parseSPDXLicenseString("Zlib");
+		String zlibLicHtmlRef = "license/Zlib";
+		String zlibLicJsonRef = "json/Zlib";
+		boolean zlibDeprecated = true;
+		tocJson.addLicense(zlib, zlibLicHtmlRef, zlibLicJsonRef, zlibDeprecated);
+		
+		SpdxListedLicense giftware = (SpdxListedLicense)LicenseInfoFactory.parseSPDXLicenseString("Giftware");
+		String giftwareLicHtmlRef = "license/giftware";
+		String giftwareLicJsonRef = "json/giftware";
+		boolean giftwareDeprecated = false;
+		tocJson.addLicense(giftware, giftwareLicHtmlRef, giftwareLicJsonRef, giftwareDeprecated);
+		
+		
+		JSONObject result = tocJson.getJsonObject();
+		assertEquals(version, result.get(SpdxRdfConstants.PROP_LICENSE_LIST_VERSION));
+		assertEquals(releaseDate, result.get("releaseDate"));
+		JSONArray licenses = (JSONArray)result.get("licenses");
+		assertEquals(3, licenses.size());
+		JSONObject firstLicense = (JSONObject)licenses.get(0);
+		assertEquals(zeroBSD.getLicenseId(), firstLicense.get(SpdxRdfConstants.PROP_LICENSE_ID));
+		assertEquals(zeroBSDLicHtmlRef, firstLicense.get("reference"));
+		assertEquals("http://spdx.org/licenses/" + zeroBSDLicJsonRef, firstLicense.get(LicenseTOCJSONFile.JSON_REFERENCE_FIELD));
+		assertEquals(zeroBSDDeprecated, firstLicense.get(SpdxRdfConstants.PROP_LIC_ID_DEPRECATED));
+		
+		JSONObject secondLicense = (JSONObject)licenses.get(1); //Note - sorted list this license should be next
+		assertEquals(giftware.getLicenseId(), secondLicense.get(SpdxRdfConstants.PROP_LICENSE_ID));
+		assertEquals(giftwareLicHtmlRef, secondLicense.get("reference"));
+		assertEquals("http://spdx.org/licenses/" + giftwareLicJsonRef, secondLicense.get(LicenseTOCJSONFile.JSON_REFERENCE_FIELD));
+		assertEquals(giftwareDeprecated, secondLicense.get(SpdxRdfConstants.PROP_LIC_ID_DEPRECATED));
+		
+		JSONObject thirdLicense = (JSONObject)licenses.get(2);
+		assertEquals(zlib.getLicenseId(), thirdLicense.get(SpdxRdfConstants.PROP_LICENSE_ID));
+		assertEquals(zlibLicHtmlRef, thirdLicense.get("reference"));
+		assertEquals("http://spdx.org/licenses/" + zlibLicJsonRef, thirdLicense.get(LicenseTOCJSONFile.JSON_REFERENCE_FIELD));
+		assertEquals(zlibDeprecated, thirdLicense.get(SpdxRdfConstants.PROP_LIC_ID_DEPRECATED));
+	}
+
+}

--- a/src/org/spdx/html/LicenseTOCJSONFile.java
+++ b/src/org/spdx/html/LicenseTOCJSONFile.java
@@ -16,6 +16,8 @@
  */
 package org.spdx.html;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.json.simple.JSONArray;
@@ -46,7 +48,8 @@ public class LicenseTOCJSONFile extends AbstractJsonFile {
 		private String licJSONReference;
 		
 		public ListedSpdxLicense(String reference, String refNumber, 
-				String licenseId, boolean osiApproved, Boolean fsfLibre, String licenseName, String[] seeAlso, boolean deprecated, String licJSONReference) {
+				String licenseId, boolean osiApproved, Boolean fsfLibre, String licenseName, String[] seeAlso, 
+				boolean deprecated, String licJSONReference) {
 			this.reference = reference;
 			this.refNumber = refNumber;
 			this.licenseId = licenseId;
@@ -152,6 +155,22 @@ public class LicenseTOCJSONFile extends AbstractJsonFile {
 		jsonObject.put(SpdxRdfConstants.PROP_LICENSE_LIST_VERSION, version);
 		jsonObject.put("releaseDate", releaseDate);
 		JSONArray licensesList = new JSONArray();
+		Collections.sort(listedLicenses, new Comparator<ListedSpdxLicense>() {
+			@Override
+			public int compare(ListedSpdxLicense o1, ListedSpdxLicense o2) {
+				if (o1 == null) {
+					if (o2 == null) {
+						return 0;
+					} else {
+						return -1;
+					}
+				} else if (o2 == null) {
+					return 1;
+				} else {
+					return o1.getLicenseId().compareTo(o2.getLicenseId());
+				}
+			}
+		});
 		for (ListedSpdxLicense license : listedLicenses) {
 			JSONObject licenseJSON = new JSONObject();
 			licenseJSON.put("reference", license.getReference());


### PR DESCRIPTION
Resolves https://github.com/spdx/LicenseListPublisher/issues/36 and https://github.com/spdx/license-list-data/issues/36

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>