### PR TITLE
Update documentation README and tool help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The Software Package Data Exchange (SPDX) specification is a standard format for
 These tools are published by the SPDX Workgroup
 see [http://spdx.org/](http://spdx.org/)
 
+See the [https://spdx.org/sites/cpstandard/files/pages/files/spdx_tools-20170327.pdf](SPDX Tools Documentation) for details on how to use the command line tools.
+
 ## Contributing
 See the file CONTRIBUTING.md for information on making contributions to the SPDX tools.
 
@@ -40,6 +42,7 @@ Example to convert a SPDX file from tag to rdf format:
     java -jar spdx-tools-jar-with-dependencies.jar TagToRDF Examples/SPDXTagExample.tag TagToRDF.rdf
 
 ## Compare utilities
+The following  tools can be used to compare one or more SPDX documents:
 
   * CompareSpdxDocs
 
@@ -54,6 +57,8 @@ Example to convert a SPDX file from tag to rdf format:
         java -jar spdx-tools-jar-with-dependencies.jar CompareMultipleSpdxDocs output.xls doc1 doc2 ... docN
 
 ## SPDX Viewer
+The following tool can be used to "Pretty Print" an SPDX document.
+
   * SPDXViewer
 
 Sample usage:
@@ -61,6 +66,8 @@ Sample usage:
     java -jar spdx-tools-jar-with-dependencies.jar SPDXViewer TestFiles/SPDXRdfExample.rdf
 
 ## Verifier
+The following tool can be used to verify an SPDX document:
+
   * Verify
 
 Sample usage:
@@ -68,11 +75,11 @@ Sample usage:
     java -jar spdx-tools-jar-with-dependencies.jar Verify TestFiles/SPDXRdfExample.rdf
 
 ## Generators
-  * LicenseRDFAGenerator
-
-        java -jar spdx-tools-jar-with-dependencies.jar LicenseRDFAGenerator licenseSpreadsheet.xls outputDirectory [version] [releasedate]
+The following tool can be used to generate an SPDX verification code from a directory of source files:
 
   * GenerateVerificationCode sourceDirectory
+  
+  Sample usage:
 
         java -jar spdx-tools-jar-with-dependencies.jar GenerateVerificationCode sourceDirectory [ignoredFilesRegex]
 
@@ -83,7 +90,7 @@ including info from 3rd Party Software
 See [LICENSE](LICENSE) file for full license text
 
     SPDX-License-Identifier:	Apache-2.0
-    PackageLicenseDeclared:		Apache-2.0
+    PackageLicenseDeclared:	Apache-2.0
 
 # Development
 

--- a/src/org/spdx/tools/Main.java
+++ b/src/org/spdx/tools/Main.java
@@ -83,7 +83,6 @@ public class Main {
 						+ "CompareSpdxDocs          doc1 doc2 [output] \n"
 						+ "GenerateVerificationCode sourceDirectory\n"
 						+ "Version\n"
-						+ "MergeSpdxDocs            masterDocument, mergedDoc1, MergedDoc2, ..., outputFile\n"
 						+ "MatchingStandardLicenses licenseTextFile");
 	}
 }


### PR DESCRIPTION
Resolves issue #183.

Adds reference to PDF documentation.

Removes reference to LicenseRDFaGenerator which is now in the separate [License List Publish](https://github.com/spdx/LicenseListPublisher) tool.
Also removed reference to merge tool in the documentation since it is not currently working.  We can add the documentation back once issue #182 is addressed.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>