### PR TITLE
Update Documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Software Package Data Exchange (SPDX) specification is a standard format for
 These tools are published by the SPDX Workgroup
 see [http://spdx.org/](http://spdx.org/)
 
-See the [SPDX Tools Documentation](https://spdx.org/sites/cpstandard/files/pages/files/spdx_tools-20170327.pdf) for details on how to use the command line tools.
+See the [SPDX Tools Documentation](https://spdx.dev/wp-content/uploads/sites/41/2017/12/spdx_tools-20170327.pdf) for details on how to use the command line tools.
 
 ## Contributing
 See the file CONTRIBUTING.md for information on making contributions to the SPDX tools.


### PR DESCRIPTION
The "SPDX Tools Documentation" link in the README changed. This commit
updates the link to point to the correct location instead of the old
link that was giving a 404 Not Found error.

Resolves #231

Signed-off-by: Rose Judge <rjudge@vmware.com>