### PR TITLE
Added configuration for javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,8 @@ This license is based on the Apache Software License, version 1.1.</extractedTex
 				<version>2.9</version>
 				<configuration>
 					<quiet>true</quiet>
-					<source>8</source>		
+					<source>8</source>	
+					<javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>	
 					<additionalparam>-Xdoclint:none</additionalparam>
 				</configuration>
 				<executions>


### PR DESCRIPTION
Signed-off-by: Gautime <gautime.idk@gmail.com>
@goneall Added configuration for javadoc plugin. This configuration was missing. Now project building successfully.

![Screenshot from 2020-06-16 20-27-24](https://user-images.githubusercontent.com/22879639/84791832-c50ab500-b010-11ea-89cc-fdd409d77369.png)
