### PR TITLE
Field addition on json files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
 			<version>3.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
 			<version>3.17</version>
@@ -154,6 +159,11 @@
 			<groupId>com.github.cliftonlabs</groupId>
 			<artifactId>json-simple</artifactId>
 			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+		    <groupId>commons-validator</groupId>
+		    <artifactId>commons-validator</artifactId>
+		    <version>1.6</version>
 		</dependency>
 	</dependencies>
 	<profiles>

--- a/src/org/spdx/html/LicenseJSONFile.java
+++ b/src/org/spdx/html/LicenseJSONFile.java
@@ -20,6 +20,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.spdx.rdfparser.SpdxRdfConstants;
 import org.spdx.rdfparser.license.SpdxListedLicense;
+import org.spdx.rdfparser.license.UrlHelper;
 
 /**
  * This class holds a JSON details file for a specific license
@@ -74,7 +75,16 @@ public class LicenseJSONFile extends AbstractJsonFile {
 		if (seeAlsos != null && seeAlsos.length > 0) {
 			JSONArray seeAlsoArray = new JSONArray();
 			for (String seeAlso:seeAlsos) {
-				seeAlsoArray.add(seeAlso);
+				JSONObject seeAlsoJsonObject = new JSONObject();
+				boolean isValidUrl = UrlHelper.urlValidator(seeAlso);
+				boolean isDeadUrl = !UrlHelper.urlLinkExists(seeAlso);
+				seeAlsoJsonObject.put(SpdxRdfConstants.RDFS_PROP_SEE_ALSO_URL, seeAlso);
+				seeAlsoJsonObject.put(SpdxRdfConstants.RDFS_PROP_SEE_ALSO_IS_DEAD, isDeadUrl);
+				seeAlsoJsonObject.put(SpdxRdfConstants.RDFS_PROP_SEE_ALSO_IS_VALID, isValidUrl);
+				seeAlsoJsonObject.put(SpdxRdfConstants.RDFS_PROP_SEE_ALSO_IS_MATCH, true);
+				seeAlsoJsonObject.put(SpdxRdfConstants.RDFS_PROP_SEE_ALSO_HAS_EXTRA_TEXT, true);
+				seeAlsoJsonObject.put(SpdxRdfConstants.RDFS_PROP_SEE_ALSO_IS_WAYBACK_LINK, true);
+				seeAlsoArray.add(seeAlsoJsonObject);
 			}
 			jsonObject.put(SpdxRdfConstants.RDFS_PROP_SEE_ALSO, seeAlsoArray);
 		}

--- a/src/org/spdx/rdfparser/SpdxRdfConstants.java
+++ b/src/org/spdx/rdfparser/SpdxRdfConstants.java
@@ -46,6 +46,12 @@ public interface SpdxRdfConstants {
 	public static final String RDFS_PROP_COMMENT = "comment";
 	public static final String RDFS_PROP_LABEL = "label";
 	public static final String RDFS_PROP_SEE_ALSO = "seeAlso";
+	public static final String RDFS_PROP_SEE_ALSO_URL = "url";
+	public static final String RDFS_PROP_SEE_ALSO_IS_VALID = "isValid";
+	public static final String RDFS_PROP_SEE_ALSO_IS_MATCH = "isMatch";
+	public static final String RDFS_PROP_SEE_ALSO_IS_DEAD = "isDead";
+	public static final String RDFS_PROP_SEE_ALSO_HAS_EXTRA_TEXT = "extraText";
+	public static final String RDFS_PROP_SEE_ALSO_IS_WAYBACK_LINK = "isWayBackLink";
 	
 	// DOAP Class Names
 	public static final String CLASS_DOAP_PROJECT = "Project";

--- a/src/org/spdx/rdfparser/license/UrlHelper.java
+++ b/src/org/spdx/rdfparser/license/UrlHelper.java
@@ -1,0 +1,36 @@
+/**
+ * 
+ */
+package org.spdx.rdfparser.license;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.apache.commons.validator.UrlValidator;
+
+/**
+ * @author Smith
+ *
+ */
+public class UrlHelper {
+	
+	public static boolean urlLinkExists(String URLName){
+	    try {
+	      HttpURLConnection.setFollowRedirects(false);
+	      HttpURLConnection con = (HttpURLConnection) new URL(URLName).openConnection();
+	      con.setRequestMethod("HEAD");
+	      return (con.getResponseCode() == HttpURLConnection.HTTP_OK);
+	    }
+	    catch (Exception e) {
+	       e.printStackTrace();
+	       return false;
+	    }
+	  }
+	
+	public static boolean urlValidator(String url){
+		// Get an UrlValidator using default schemes
+		UrlValidator defaultValidator = new UrlValidator();
+		return defaultValidator.isValid(url);
+	}
+
+}


### PR DESCRIPTION
Added the commons-validator dependency to handle the verification of the validity of urls.
The urlHelper class contains functions used to determine link validity and live-status.

I have tested this locally by installing the tools repo on my local maven repo using the command:
`
mvn install:install-file -Dfile=spdx-tools-2.2.2-SNAPSHOT-jar-with-dependencies.jar -DgroupId=org.spdx -DartifactId=spdx-tools -Dversion=2.2.2 -Dpackaging=jar
`

Then I built the LicenseList publisher repo and ran:
`
java -jar licenseListPublisher-2.1.22-jar-with-dependencies.jar LicenseRDFAGenerator /path_to_dir_containing_xml_licenses /path_to_dir_where_generated_data_should_be_saved
`

And in the generated json files, here is an example:
```
"licenseId": "0BSD",
  "seeAlso": [
    {
      "isValid": true,
      "isWayBackLink": true,
      "extraText": true,
      "isMatch": true,
      "url": "http://landley.net/toybox/license.html",
      "isDead": false
    },
    {
      "isValid": true,
      "isWayBackLink": true,
      "extraText": true,
      "isMatch": true,
      "url": "http://landley.net/toybox/license2.html",
      "isDead": true
    },
    {
      "isValid": false,
      "isWayBackLink": true,
      "extraText": true,
      "isMatch": true,
      "url": "http://invalidURL",
      "isDead": true
    },
    {
      "isValid": true,
      "isWayBackLink": true,
      "extraText": true,
      "isMatch": true,
      "url": "https://threejs.org/examples/webgl_objconvert_test.html",
      "isDead": true
    }
  ],
  "isOsiApproved": true
```
@goneall Please have a look.