### PR TITLE
Revert "Bump log4j-core from 2.10.0 to 2.13.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-core</artifactId>
-		    <version>2.13.2</version>
+		    <version>2.10.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Reverts spdx/tools#240

This version of LOG4J appears to be incompatible with the Jena version currently in use