### PR TITLE
Add support for cached licenses

### DIFF
--- a/src/org/spdx/rdfparser/SpdxDocumentContainer.java
+++ b/src/org/spdx/rdfparser/SpdxDocumentContainer.java
@@ -74,7 +74,7 @@ public class SpdxDocumentContainer implements IModelContainer, SpdxRdfConstants 
 	public static final String TWO_POINT_TWO_VERSION = "SPDX-2.2";
 	public static final String CURRENT_SPDX_VERSION = TWO_POINT_TWO_VERSION;
 
-	public static final String CURRENT_IMPLEMENTATION_VERSION = "2.2.0";
+	public static final String CURRENT_IMPLEMENTATION_VERSION = "2.2.3";
 
 	static Set<String> SUPPORTED_SPDX_VERSIONS = Sets.newHashSet();
 


### PR DESCRIPTION
Added environment and property variables to allow a directory of license JSON-LD files to be accessed locally.

This speeds up the first license compare by 16X.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>