### PR TITLE
Update log4j to version 2.16.0 and guava to version 29.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.spdx</groupId>
 	<artifactId>spdx-tools</artifactId>
-	<version>2.2.6-SNAPSHOT</version>
+	<version>2.2.6</version>
 	<name>SPDX tools</name>
 	<description>SPDX tools</description>
 	<licenses>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>24.1.1-jre</version>
+			<version>29.0-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.spullara.mustache.java</groupId>
@@ -122,17 +122,17 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-api</artifactId>
-		    <version>2.10.0</version>
+		    <version>2.16.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-core</artifactId>
-		    <version>2.10.0</version>
+		    <version>2.16.0</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j-impl</artifactId>
-		    <version>2.10.0</version>
+		    <version>2.16.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Resolves critical security issue CVE-2021-44228
Resolves moderate security issue CVE-2021-45046
Resolves minor security issue CVE-2018-10237
Resolves minor security issue CVE-2020-8908

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>