### PR TITLE
Update GSON to version 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.0</version>
+			<version>2.8.9</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.saxon</groupId>


### PR DESCRIPTION
Resolves potential denial of service vulnerability CVE-2022-25647

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>