### PR TITLE
Fix flaky test by LinkedHashSet

### DIFF
--- a/src/org/spdx/rdfparser/license/LicenseSet.java
+++ b/src/org/spdx/rdfparser/license/LicenseSet.java
@@ -44,7 +44,7 @@ import org.apache.jena.util.iterator.ExtendedIterator;
  */
 public abstract class LicenseSet extends AnyLicenseInfo {
 
-	protected Set<AnyLicenseInfo> licenseInfos = Sets.newHashSet();
+	protected Set<AnyLicenseInfo> licenseInfos = Sets.newLinkedHashSet();
 
 	/**
 	 * @param modelContainer container which includes the license


### PR DESCRIPTION
### Description
A test named `org.spdx.compare.TestPackageSheet#testDeclaredLicenseCol`, can fail nondeterministically when been run in different JVMs. The issue can be found by running following command under root directory after installation:
```shell
 mvn -pl . edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.spdx.compare.TestPackageSheet#testDeclaredLicenseCol
```

### Reason for Flakiness
In lines `192` and `193` in the test function, `toString()` is called. In the implementation of `AnyLicenseInfo`'s `toString()`, the function calls a `HashSet` iterator, which does not guarantee a deterministic order. As a result, lines`192` and `193`  in `org.spdx.compare.TestPackageSheet#testDeclaredLicenseCol` can raise an assertion error due to permutation of the string-represented equations.

### Sample Failure
```
Failed tests:   testDeclaredLicenseCol(org.spdx.compare.TestPackageSheet): 
expected:<(L[icenseRef-3 AND LGPL-2.0])> 
but was:<(L[GPL-2.0 AND LicenseRef-3])>
```
### Fixes
Change 'newHashSet()' to 'newLinkedHashSet()' in 'LicenseSet.java', then it can be resovled.